### PR TITLE
[TAT-123] Fix go binary download link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Buildkite Test Splitter
 ## Installation
-The latest version of Buildkite Test Splitter can be downloaded from https://api.github.com/repos/buildkite/test-splitter/releases/latest
+The latest version of Buildkite Test Splitter can be downloaded from https://github.com/buildkite/test-splitter/releases
 
 ### Supported OS/Architecture
 ARM and AMD architecture for linux and darwin 


### PR DESCRIPTION
### Description
We noticed the download link to the test splitter is incorrect. Update the link so it won't be misleading.

### Context

https://linear.app/buildkite/issue/TAT-123/fix-go-binary-download-link-in-readme

### Changes

Update the download link
