### PR TITLE
Cleanup env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The latest version of Buildkite Test Splitter can be downloaded from https://github.com/buildkite/test-splitter/releases
 
 ### Supported OS/Architecture
-ARM and AMD architecture for linux and darwin 
+ARM and AMD architecture for linux and darwin
 
 The available Go binaries
 - test-splitter-darwin-amd64
@@ -14,27 +14,29 @@ The available Go binaries
 ## Using the Test Splitter
 
 ### ENV variables
-Please ensure that these default Buildkite ENV variables are available in the environment you are running your tests in. We will detect these env vars automatically, and use them to orchestrate the test splitting
-- `BUILDKITE_BUILD_ID`
-- `BUILDKITE_PARALLEL_JOB_COUNT`
-- `BUILDKITE_PARALLEL_JOB`
 
-We also need the API token for the Test Suite that has the test data for the build. This will be available in the settings page for the Test Suite. We are expecting this key to be available as `BUILDKITE_SUITE_TOKEN`.
+| Environment Variable | Default Value | Description |
+| ---- | ---- | ----------- |
+|  `BUILDKITE_PARALLEL_JOB_COUNT` | - | Required, total number of parallelism |
+|  `BUILDKITE_PARALLEL_JOB` | - | Required, test plan for specific node |
+| `BUILDKITE_SPLITTER_SUITE_TOKEN` | `BUILDKITE_ANALYTICS_TOKEN` | Required, unique token for Test Suite that is being parallelised |
+|  `BUILDKITE_SPLITTER_IDENTIFIER` | `BUILDKITE_BUILD_ID` | Required, use default unless you have a specific use case |
+| `BUILDKITE_SPLITTER_TEST_FILE_PATTERN` | `spec/**/*_spec.rb` | Optional, glob pattern for discovering test files that need to be executed. </br> *It accepts pattern syntax supported by [zzglob](https://github.com/DrJosh9000/zzglob?tab=readme-ov-file#pattern-syntax) library*. |
+| `BUILDKITE_SPLITTER_TEST_FILE_EXCLUDE_PATTERN` | - | Optional, glob pattern to use for excluding test files or directory. </br> *It accepts pattern syntax supported by [zzglob](https://github.com/DrJosh9000/zzglob?tab=readme-ov-file#pattern-syntax) library.* |
 
-Additionally, you can configure the Test Splitter using the following optional environment variables:
-| Environment Variable | Description |
-| ---- | ----------- |
-| `BUILDKITE_SPLITTER_TEST_FILE_PATTERN` | Glob pattern for discovering test files that need to be executed. The default value for Rspec is `spec/**/*_spec.rb`. </br> *It accepts pattern syntax supported by [zzglob](https://github.com/DrJosh9000/zzglob?tab=readme-ov-file#pattern-syntax) library*. |
-| `BUILDKITE_SPLITTER_TEST_FILE_EXCLUDE_PATTERN` | Glob pattern to use for excluding test files or directory. </br> *It accepts pattern syntax supported by [zzglob](https://github.com/DrJosh9000/zzglob?tab=readme-ov-file#pattern-syntax) library.* |
+For most use cases, Test Splitter should work out of the box due to the default values available from your Buildkite environment.
 
+However, you'll need to set `BUILDKITE_SPLITTER_SUITE_TOKEN` if your test collector doesn't use the `BUILDKITE_ANALYTICS_TOKEN` value, or your pipeline has multiple suites.
+
+You can also set the `BUILDKITE_SPLITTER_TEST_FILE_PATTERN` or `BUILDKITE_SPLITTER_TEST_FILE_EXCLUDE_PATTERN` if you need to filter the tests selected for execution.
 
 ### Run the Test Splitter
-Please download the executable and make it available in your testing environment. 
+Please download the executable and make it available in your testing environment.
 
-Once that's available, you'll need to modify permissions to make the binary executable, and then execute it. The test splitter will run the rspec specs for you, so you'll run the test splitter in lieu of the relevant rspec command. Under the hood, the test splitter will execute `bin/rspec YOUR_TEST_PLAN` so if your rspec installation is different or if you are using any custom flags, this may not work for your test set up. Please get in touch with one of the Test Splitting team and we'll see what we can do! 
+Once that's available, you'll need to modify permissions to make the binary executable, and then execute it. The test splitter will run the rspec specs for you, so you'll run the test splitter in lieu of the relevant rspec command. Under the hood, the test splitter will execute `bin/rspec YOUR_TEST_PLAN` so if your rspec installation is different or if you are using any custom flags, this may not work for your test set up. Please get in touch with one of the Test Splitting team and we'll see what we can do!
 
 Otherwise, your script for executing specs may look something like:
-```  
+```
 chmod +x test-splitter
 ./test-splitter # fetches the test plan for this node, and then executes the rspec tests
 ```

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -15,7 +15,7 @@ func setEnv(t *testing.T) {
 	os.Setenv("BUILDKITE_SPLITTER_BASE_URL", "https://build.kite")
 	os.Setenv("BUILDKITE_SPLITTER_MODE", "static")
 	os.Setenv("BUILDKITE_BUILD_ID", "xyz")
-	os.Setenv("BUILDKITE_SUITE_TOKEN", "my_token")
+	os.Setenv("BUILDKITE_SPLITTER_SUITE_TOKEN", "my_token")
 }
 
 func TestNewConfig(t *testing.T) {
@@ -79,7 +79,7 @@ func TestNewConfig_MissingConfigWithDefault(t *testing.T) {
 func TestNewConfig_InvalidConfig(t *testing.T) {
 	setEnv(t)
 	os.Setenv("BUILDKITE_SPLITTER_MODE", "dynamic")
-	os.Unsetenv("BUILDKITE_SUITE_TOKEN")
+	os.Unsetenv("BUILDKITE_SPLITTER_SUITE_TOKEN")
 	defer os.Clearenv()
 
 	_, err := New()

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -12,6 +12,9 @@ func TestGetEnvWithDefault(t *testing.T) {
 	os.Setenv("EMPTY_KEY", "")
 	defer os.Unsetenv("EMPTY_KEY")
 
+	os.Setenv("OTHER_KEY", "other_value")
+	defer os.Unsetenv("OTHER_KEY")
+
 	tests := []struct {
 		key          string
 		defaultValue string
@@ -31,6 +34,11 @@ func TestGetEnvWithDefault(t *testing.T) {
 			key:          "EMPTY_KEY",
 			defaultValue: "empty_default_value",
 			want:         "empty_default_value",
+		},
+		{
+			key:          "EMPTY_KEY",
+			defaultValue: os.Getenv("OTHER_KEY"),
+			want:         "other_value",
 		},
 	}
 

--- a/internal/config/read.go
+++ b/internal/config/read.go
@@ -11,21 +11,20 @@ import (
 // set default values for ServerBaseUrl and Mode if they are not set.
 //
 // Currently, it reads the following environment variables:
-// - BUILDKITE_BUILD_ID (Identifier)
+// - BUILDKITE_SPLITTER_IDENTIFIER (Identifier)
 // - BUILDKITE_PARALLEL_JOB_COUNT (Parallelism)
 // - BUILDKITE_PARALLEL_JOB (NodeIndex)
 // - BUILDKITE_SPLITTER_BASE_URL (ServerBaseUrl)
 // - BUILDKITE_SPLITTER_MODE (Mode)
-// - BUILDKITE_SUITE_TOKEN (SuiteToken)
+// - BUILDKITE_SPLITTER_SUITE_TOKEN (SuiteToken)
 //
 // If we are going to support other CI environment in the future,
 // we will need to change where we read the configuration from.
 func (c *Config) readFromEnv() error {
 	var errs InvalidConfigError
 
-	c.SuiteToken = os.Getenv("BUILDKITE_SUITE_TOKEN")
-	c.Identifier = os.Getenv("BUILDKITE_BUILD_ID")
-
+	c.SuiteToken = getEnvWithDefault("BUILDKITE_SPLITTER_SUITE_TOKEN", os.Getenv("BUILDKITE_ANALYTICS_TOKEN"))
+	c.Identifier = getEnvWithDefault("BUILDKITE_SPLITTER_IDENTIFIER", os.Getenv("BUILDKITE_BUILD_ID"))
 	c.ServerBaseUrl = getEnvWithDefault("BUILDKITE_SPLITTER_BASE_URL", "https://buildkite.com")
 	c.Mode = getEnvWithDefault("BUILDKITE_SPLITTER_MODE", "static")
 

--- a/internal/config/read_test.go
+++ b/internal/config/read_test.go
@@ -14,7 +14,7 @@ func TestConfigReadFromEnv(t *testing.T) {
 	os.Setenv("BUILDKITE_SPLITTER_BASE_URL", "https://buildkite.localhost")
 	os.Setenv("BUILDKITE_SPLITTER_MODE", "static")
 	os.Setenv("BUILDKITE_BUILD_ID", "123")
-	os.Setenv("BUILDKITE_SUITE_TOKEN", "my_token")
+	os.Setenv("BUILDKITE_SPLITTER_SUITE_TOKEN", "my_token")
 	defer os.Clearenv()
 
 	c := Config{}


### PR DESCRIPTION
### Description

Making changes to these ENV vars:

BUILDKITE_SUITE_TOKEN
A more appropriate name for this is probably BUILDKITE_SPLITTER_SUITE_TOKEN  and we should default this value to BUILDKITE_ANALYTICS_TOKEN as that's what we use in the collectors. 

BUILDKITE_BUILD_ID
We're using this as a unique identifier for test plans. We should call this value BUILDKITE_SPLITTER_IDENTIFIER instead so people can set their own if they wish, and default its value to BUILDKITE_BUILD_ID

Will also follow up with a PR to add the new BUILDKITE_SPLITTER_SUITE_TOKEN to the bk/bk pipeline definition. 

### Testing

Will test after this is released with PR with new ENV vars on bk/bk