### PR TITLE
Add release pipeline back in

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -39,3 +39,9 @@ steps:
           arch:
             - amd64
             - arm64
+
+  - name: ":pipeline: Upload Release Pipeline"
+    command: ".buildkite/steps/upload-release-step.sh"
+    depends_on:
+      - build-binary
+    branches: "main"


### PR DESCRIPTION
### Description

This was accidentally removed in https://github.com/buildkite/test-splitter/pull/37 
