### PR TITLE
Allow configuration of Rspec command to be executed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,7 @@ require (
 	github.com/google/go-cmp v0.6.0
 )
 
-require github.com/DrJosh9000/zzglob v0.1.0
+require (
+	github.com/DrJosh9000/zzglob v0.1.0
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
+)

--- a/go.sum
+++ b/go.sum
@@ -4,4 +4,6 @@ github.com/buildkite/roko v1.2.0 h1:hbNURz//dQqNl6Eo9awjQOVOZwSDJ8VEbBDxSfT9rGQ=
 github.com/buildkite/roko v1.2.0/go.mod h1:23R9e6nHxgedznkwwfmqZ6+0VJZJZ2Sg/uVcp2cP46I=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 gotest.tools/v3 v3.5.1 h1:EENdUnS3pdur5nybKYIh2Vfgc8IUNBjxDPSjtiJcOzU=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,8 @@ type Config struct {
 	Identifier string
 	// Node index is index of the current node.
 	NodeIndex int
+	// TestCommand is the command to run the tests.
+	TestCommand string
 }
 
 // New wraps the readFromEnv and validate functions to create a new Config struct.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -16,6 +16,7 @@ func setEnv(t *testing.T) {
 	os.Setenv("BUILDKITE_SPLITTER_MODE", "static")
 	os.Setenv("BUILDKITE_BUILD_ID", "xyz")
 	os.Setenv("BUILDKITE_SPLITTER_SUITE_TOKEN", "my_token")
+	os.Setenv("BUILDKITE_TEST_SPLITTER_CMD", "bin/rspec {{testExamples}}")
 }
 
 func TestNewConfig(t *testing.T) {
@@ -34,6 +35,7 @@ func TestNewConfig(t *testing.T) {
 		Mode:          "static",
 		Identifier:    "xyz",
 		SuiteToken:    "my_token",
+		TestCommand:   "bin/rspec {{testExamples}}",
 	}
 
 	if diff := cmp.Diff(c, want); diff != "" {
@@ -55,6 +57,7 @@ func TestNewConfig_MissingConfigWithDefault(t *testing.T) {
 	setEnv(t)
 	os.Unsetenv("BUILDKITE_SPLITTER_MODE")
 	os.Unsetenv("BUILDKITE_SPLITTER_BASE_URL")
+	os.Unsetenv("BUILDKITE_TEST_SPLITTER_CMD")
 	defer os.Clearenv()
 
 	c, err := New()
@@ -69,6 +72,7 @@ func TestNewConfig_MissingConfigWithDefault(t *testing.T) {
 		Mode:          "static",
 		Identifier:    "xyz",
 		SuiteToken:    "my_token",
+		TestCommand:   "bundle exec rspec {{testExamples}}",
 	}
 
 	if diff := cmp.Diff(c, want); diff != "" {

--- a/internal/config/read.go
+++ b/internal/config/read.go
@@ -17,6 +17,7 @@ import (
 // - BUILDKITE_SPLITTER_BASE_URL (ServerBaseUrl)
 // - BUILDKITE_SPLITTER_MODE (Mode)
 // - BUILDKITE_SPLITTER_SUITE_TOKEN (SuiteToken)
+// - BUILDKITE_TEST_SPLITTER_CMD (TestCommand)
 //
 // If we are going to support other CI environment in the future,
 // we will need to change where we read the configuration from.
@@ -27,6 +28,7 @@ func (c *Config) readFromEnv() error {
 	c.Identifier = getEnvWithDefault("BUILDKITE_SPLITTER_IDENTIFIER", os.Getenv("BUILDKITE_BUILD_ID"))
 	c.ServerBaseUrl = getEnvWithDefault("BUILDKITE_SPLITTER_BASE_URL", "https://buildkite.com")
 	c.Mode = getEnvWithDefault("BUILDKITE_SPLITTER_MODE", "static")
+	c.TestCommand = getEnvWithDefault("BUILDKITE_TEST_SPLITTER_CMD", "bundle exec rspec {{testExamples}}")
 
 	parallelism := os.Getenv("BUILDKITE_PARALLEL_JOB_COUNT")
 	parallelismInt, err := strconv.Atoi(parallelism)

--- a/internal/config/read_test.go
+++ b/internal/config/read_test.go
@@ -15,6 +15,7 @@ func TestConfigReadFromEnv(t *testing.T) {
 	os.Setenv("BUILDKITE_SPLITTER_MODE", "static")
 	os.Setenv("BUILDKITE_BUILD_ID", "123")
 	os.Setenv("BUILDKITE_SPLITTER_SUITE_TOKEN", "my_token")
+	os.Setenv("BUILDKITE_TEST_SPLITTER_CMD", "bin/rspec {{testExamples}}")
 	defer os.Clearenv()
 
 	c := Config{}
@@ -27,6 +28,7 @@ func TestConfigReadFromEnv(t *testing.T) {
 		Mode:          "static",
 		Identifier:    "123",
 		SuiteToken:    "my_token",
+		TestCommand:   "bin/rspec {{testExamples}}",
 	}
 
 	if err != nil {
@@ -41,8 +43,10 @@ func TestConfigReadFromEnv(t *testing.T) {
 func TestConfigReadFromEnv_MissingConfigWithDefault(t *testing.T) {
 	os.Setenv("BUILDKITE_SPLITTER_BASE_URL", "")
 	os.Setenv("BUILDKITE_SPLITTER_MODE", "")
+	os.Setenv("BUILDKITE_TEST_SPLITTER_CMD", "")
 	defer os.Unsetenv("BUILDKITE_SPLITTER_BASE_URL")
 	defer os.Unsetenv("BUILDKITE_SPLITTER_MODE")
+	defer os.Unsetenv("BUILDKITE_TEST_SPLITTER_CMD")
 
 	c := Config{}
 	c.readFromEnv()
@@ -52,6 +56,10 @@ func TestConfigReadFromEnv_MissingConfigWithDefault(t *testing.T) {
 
 	if c.Mode != "static" {
 		t.Errorf("Mode = %v, want %v", c.Mode, "static")
+	}
+
+	if c.TestCommand != "bundle exec rspec {{testExamples}}" {
+		t.Errorf("TestCommand = %v, want %v", c.TestCommand, "bundle exec rspec {{testExamples}}")
 	}
 }
 

--- a/internal/runner/rspec.go
+++ b/internal/runner/rspec.go
@@ -36,8 +36,7 @@ func (r Rspec) GetFiles() ([]string, error) {
 // Command returns an exec.Cmd that will run the rspec command
 func (r Rspec) Command(testCases []string) *exec.Cmd {
 	commandName, commandArgs := r.commandNameAndArgs(testCases)
-
-	fmt.Println(commandName, strings.Join(commandArgs, " "))
+	fmt.Printf("%q\n", commandName+" "+strings.Join(commandArgs, " "))
 
 	cmd := exec.Command(commandName, commandArgs...)
 	cmd.Stderr = os.Stderr

--- a/internal/runner/rspec.go
+++ b/internal/runner/rspec.go
@@ -33,14 +33,25 @@ func (r Rspec) GetFiles() ([]string, error) {
 }
 
 // Command returns an exec.Cmd that will run the rspec command
-func (Rspec) Command(testCases []string) *exec.Cmd {
-	args := []string{"--options", ".rspec.ci"}
+func (Rspec) Command(testCases []string, testCommandArgs []string) *exec.Cmd {
+	testCommand := "bundle exec rspec"
+	testArgs := testCases
 
-	args = append(args, testCases...)
+	if len(testCommandArgs) > 0 {
+		index := -1
+		for i, item := range testCommandArgs {
+			if item == "{{testExample}}" {
+				index = i
+				break
+			}
+		}
+		testCommand = strings.Join(testCommandArgs[:index], " ")
+		testArgs = append(testArgs, testCommandArgs[index+1:]...)
+	}
 
-	fmt.Println("bin/rspec", strings.Join(args, " "))
+	fmt.Println(testCommand, strings.Join(testArgs, " "))
 
-	cmd := exec.Command("bin/rspec", args...)
+	cmd := exec.Command(testCommand, testArgs...)
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 	return cmd

--- a/internal/runner/rspec.go
+++ b/internal/runner/rspec.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"slices"
 	"strings"
 )
 

--- a/internal/runner/rspec.go
+++ b/internal/runner/rspec.go
@@ -68,13 +68,7 @@ func (Rspec) commandNameAndArgs(testCases []string, commandLineArgs []string) (s
 	commandArgs := []string{}
 	// if commandLineArgs is not empty, using customized test command
 	if len(commandLineArgs) > 0 {
-		index := -1
-		for i, item := range commandLineArgs {
-			if strings.Compare(item, "{{testExamples}}") == 0 {
-				index = i
-				break
-			}
-		}
+		index := slices.Index(commandLineArgs, "{{testExamples}}")
 		// Command name is the first element of the command line args
 		commandName = commandLineArgs[0]
 		// The rest of the command line args are the arguments of the test command

--- a/internal/runner/rspec.go
+++ b/internal/runner/rspec.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/exec"
 	"slices"
-	"strings"
 
 	"github.com/kballard/go-shellquote"
 )
@@ -41,7 +40,7 @@ func (r Rspec) Command(testCases []string, testCommand string) (*exec.Cmd, error
 	if err != nil {
 		return nil, err
 	}
-	fmt.Printf("%q\n", commandName+" "+strings.Join(commandArgs, " "))
+	fmt.Println(shellquote.Join(append([]string{commandName}, commandArgs...)...))
 
 	cmd := exec.Command(commandName, commandArgs...)
 	cmd.Stderr = os.Stderr

--- a/internal/runner/rspec_test.go
+++ b/internal/runner/rspec_test.go
@@ -7,31 +7,60 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestRspecCommand_Default(t *testing.T) {
+func TestCommandNameAndArgs_WithCommandArgs(t *testing.T) {
+	rspec := Rspec{}
+	testCases := []string{"spec/models/user_spec.rb", "spec/models/billing_spec.rb"}
+	testArgs := []string{"bin/rspec", "--options", "{{testExamples}}", "--format"}
+
+	gotName, gotArgs := rspec.commandNameAndArgs(testCases, testArgs)
+
+	wantName := "bin/rspec"
+	wantArgs := []string{"--options", "spec/models/user_spec.rb", "spec/models/billing_spec.rb", "--format"}
+
+	if diff := cmp.Diff(gotName, wantName); diff != "" {
+		t.Errorf("Rspec.commandNameAndArgs() diff (-got +want):\n%s", diff)
+	}
+	if diff := cmp.Diff(gotArgs, wantArgs); diff != "" {
+		t.Errorf("Rspec.commandNameAndArgs() diff (-got +want):\n%s", diff)
+	}
+}
+
+func TestCommandNameAndArgs_WithoutTestPlaceholder(t *testing.T) {
+	rspec := Rspec{}
+	testCases := []string{"spec/models/user_spec.rb", "spec/models/billing_spec.rb"}
+	testArgs := []string{"bin/rspec", "--options", "--format"}
+
+	gotName, gotArgs := rspec.commandNameAndArgs(testCases, testArgs)
+
+	wantName := "bin/rspec"
+	wantArgs := []string{"--options", "--format", "spec/models/user_spec.rb", "spec/models/billing_spec.rb"}
+
+	if diff := cmp.Diff(gotName, wantName); diff != "" {
+		t.Errorf("Rspec.commandNameAndArgs() diff (-got +want):\n%s", diff)
+	}
+	if diff := cmp.Diff(gotArgs, wantArgs); diff != "" {
+		t.Errorf("Rspec.commandNameAndArgs() diff (-got +want):\n%s", diff)
+	}
+}
+
+func TestCommandNameAndArgs_DefaultCommand(t *testing.T) {
 	rspec := Rspec{}
 	testCases := []string{"spec/models/user_spec.rb", "spec/models/billing_spec.rb"}
 	testArgs := []string{}
 
-	got := rspec.Command(testCases, testArgs)
+	gotName, gotArgs := rspec.commandNameAndArgs(testCases, testArgs)
 
-	want := "bundle exec rspec spec/models/user_spec.rb spec/models/billing_spec.rb"
-	if diff := cmp.Diff(got.String(), want); diff != "" {
-		t.Errorf("Rspec.Command() diff (-got +want):\n%s", diff)
+	wantName := "bundle"
+	wantArgs := []string{"exec", "rspec", "spec/models/user_spec.rb", "spec/models/billing_spec.rb"}
+
+	if diff := cmp.Diff(gotName, wantName); diff != "" {
+		t.Errorf("Rspec.commandNameAndArgs() diff (-got +want):\n%s", diff)
+	}
+	if diff := cmp.Diff(gotArgs, wantArgs); diff != "" {
+		t.Errorf("Rspec.commandNameAndArgs() diff (-got +want):\n%s", diff)
 	}
 }
 
-func TestRspecCommand_WithTestCommandArgs(t *testing.T) {
-	rspec := Rspec{}
-	testCases := []string{"spec/models/user_spec.rb", "spec/models/billing_spec.rb"}
-	testArgs := []string{"bin/rspec", "--options", "{{testExample}}", "--format"}
-
-	got := rspec.Command(testCases, testArgs)
-
-	want := "bin/rspec --options spec/models/user_spec.rb spec/models/billing_spec.rb --format"
-	if diff := cmp.Diff(got.String(), want); diff != "" {
-		t.Errorf("Rspec.Command() diff (-got +want):\n%s", diff)
-	}
-}
 func TestRspecDiscoveryPattern_Default(t *testing.T) {
 	rspec := Rspec{}
 	got := rspec.discoveryPattern()

--- a/internal/runner/rspec_test.go
+++ b/internal/runner/rspec_test.go
@@ -14,16 +14,19 @@ func TestCommandNameAndArgs_WithInterpolationPlaceholder(t *testing.T) {
 	testCases := []string{"spec/models/user_spec.rb", "spec/models/billing_spec.rb"}
 	testCommand := "bin/rspec --options {{testExamples}} --format"
 
-	gotName, gotArgs, _ := rspec.commandNameAndArgs(testCases, testCommand)
+	gotName, gotArgs, err := rspec.commandNameAndArgs(testCases, testCommand)
+	if err != nil {
+		t.Errorf("Rspec.commandNameAndArgs(%q, %q) error = %v", testCases, testCommand, err)
+	}
 
 	wantName := "bin/rspec"
 	wantArgs := []string{"--options", "spec/models/user_spec.rb", "spec/models/billing_spec.rb", "--format"}
 
 	if diff := cmp.Diff(gotName, wantName); diff != "" {
-		t.Errorf("Rspec.commandNameAndArgs() diff (-got +want):\n%s", diff)
+		t.Errorf("Rspec.commandNameAndArgs(%q, %q) diff (-got +want):\n%s", testCases, testCommand, diff)
 	}
 	if diff := cmp.Diff(gotArgs, wantArgs); diff != "" {
-		t.Errorf("Rspec.commandNameAndArgs() diff (-got +want):\n%s", diff)
+		t.Errorf("Rspec.commandNameAndArgs(%q, %q) diff (-got +want):\n%s", testCases, testCommand, diff)
 	}
 }
 
@@ -32,16 +35,19 @@ func TestCommandNameAndArgs_WithoutInterpolationPlaceholder(t *testing.T) {
 	testCases := []string{"spec/models/user_spec.rb", "spec/models/billing_spec.rb"}
 	testCommand := "bin/rspec --options --format"
 
-	gotName, gotArgs, _ := rspec.commandNameAndArgs(testCases, testCommand)
+	gotName, gotArgs, err := rspec.commandNameAndArgs(testCases, testCommand)
+	if err != nil {
+		t.Errorf("Rspec.commandNameAndArgs(%q, %q) error = %v", testCases, testCommand, err)
+	}
 
 	wantName := "bin/rspec"
 	wantArgs := []string{"--options", "--format", "spec/models/user_spec.rb", "spec/models/billing_spec.rb"}
 
 	if diff := cmp.Diff(gotName, wantName); diff != "" {
-		t.Errorf("Rspec.commandNameAndArgs() diff (-got +want):\n%s", diff)
+		t.Errorf("Rspec.commandNameAndArgs(%q, %q) diff (-got +want):\n%s", testCases, testCommand, diff)
 	}
 	if diff := cmp.Diff(gotArgs, wantArgs); diff != "" {
-		t.Errorf("Rspec.commandNameAndArgs() diff (-got +want):\n%s", diff)
+		t.Errorf("Rspec.commandNameAndArgs(%q, %q) diff (-got +want):\n%s", testCases, testCommand, diff)
 	}
 }
 

--- a/internal/runner/rspec_test.go
+++ b/internal/runner/rspec_test.go
@@ -7,13 +7,12 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestCommandNameAndArgs_WithCommandArgs(t *testing.T) {
+func TestCommandNameAndArgs_WithInterpolationPlaceholder(t *testing.T) {
 	rspec := Rspec{}
 	testCases := []string{"spec/models/user_spec.rb", "spec/models/billing_spec.rb"}
-	os.Setenv("BUILDKITE_TEST_SPLITTER_CMD", "bin/rspec --options {{testExamples}} --format")
-	defer os.Unsetenv("BUILDKITE_TEST_SPLITTER_CMD")
+	testCommand := "bin/rspec --options {{testExamples}} --format"
 
-	gotName, gotArgs := rspec.commandNameAndArgs(testCases)
+	gotName, gotArgs := rspec.commandNameAndArgs(testCases, testCommand)
 
 	wantName := "bin/rspec"
 	wantArgs := []string{"--options", "spec/models/user_spec.rb", "spec/models/billing_spec.rb", "--format"}
@@ -26,33 +25,15 @@ func TestCommandNameAndArgs_WithCommandArgs(t *testing.T) {
 	}
 }
 
-func TestCommandNameAndArgs_WithoutTestPlaceholder(t *testing.T) {
+func TestCommandNameAndArgs_WithoutInterpolationPlaceholder(t *testing.T) {
 	rspec := Rspec{}
 	testCases := []string{"spec/models/user_spec.rb", "spec/models/billing_spec.rb"}
-	os.Setenv("BUILDKITE_TEST_SPLITTER_CMD", "bin/rspec --options --format")
-	defer os.Unsetenv("BUILDKITE_TEST_SPLITTER_CMD")
+	testCommand := "bin/rspec --options --format"
 
-	gotName, gotArgs := rspec.commandNameAndArgs(testCases)
+	gotName, gotArgs := rspec.commandNameAndArgs(testCases, testCommand)
 
 	wantName := "bin/rspec"
 	wantArgs := []string{"--options", "--format", "spec/models/user_spec.rb", "spec/models/billing_spec.rb"}
-
-	if diff := cmp.Diff(gotName, wantName); diff != "" {
-		t.Errorf("Rspec.commandNameAndArgs() diff (-got +want):\n%s", diff)
-	}
-	if diff := cmp.Diff(gotArgs, wantArgs); diff != "" {
-		t.Errorf("Rspec.commandNameAndArgs() diff (-got +want):\n%s", diff)
-	}
-}
-
-func TestCommandNameAndArgs_DefaultCommand(t *testing.T) {
-	rspec := Rspec{}
-	testCases := []string{"spec/models/user_spec.rb", "spec/models/billing_spec.rb"}
-
-	gotName, gotArgs := rspec.commandNameAndArgs(testCases)
-
-	wantName := "bundle"
-	wantArgs := []string{"exec", "rspec", "spec/models/user_spec.rb", "spec/models/billing_spec.rb"}
 
 	if diff := cmp.Diff(gotName, wantName); diff != "" {
 		t.Errorf("Rspec.commandNameAndArgs() diff (-got +want):\n%s", diff)

--- a/internal/runner/rspec_test.go
+++ b/internal/runner/rspec_test.go
@@ -7,6 +7,31 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+func TestRspecCommand_Default(t *testing.T) {
+	rspec := Rspec{}
+	testCases := []string{"spec/models/user_spec.rb", "spec/models/billing_spec.rb"}
+	testArgs := []string{}
+
+	got := rspec.Command(testCases, testArgs)
+
+	want := "bundle exec rspec spec/models/user_spec.rb spec/models/billing_spec.rb"
+	if diff := cmp.Diff(got.String(), want); diff != "" {
+		t.Errorf("Rspec.Command() diff (-got +want):\n%s", diff)
+	}
+}
+
+func TestRspecCommand_WithTestCommandArgs(t *testing.T) {
+	rspec := Rspec{}
+	testCases := []string{"spec/models/user_spec.rb", "spec/models/billing_spec.rb"}
+	testArgs := []string{"bin/rspec", "--options", "{{testExample}}", "--format"}
+
+	got := rspec.Command(testCases, testArgs)
+
+	want := "bin/rspec --options spec/models/user_spec.rb spec/models/billing_spec.rb --format"
+	if diff := cmp.Diff(got.String(), want); diff != "" {
+		t.Errorf("Rspec.Command() diff (-got +want):\n%s", diff)
+	}
+}
 func TestRspecDiscoveryPattern_Default(t *testing.T) {
 	rspec := Rspec{}
 	got := rspec.discoveryPattern()

--- a/internal/runner/rspec_test.go
+++ b/internal/runner/rspec_test.go
@@ -10,9 +10,10 @@ import (
 func TestCommandNameAndArgs_WithCommandArgs(t *testing.T) {
 	rspec := Rspec{}
 	testCases := []string{"spec/models/user_spec.rb", "spec/models/billing_spec.rb"}
-	testArgs := []string{"bin/rspec", "--options", "{{testExamples}}", "--format"}
+	os.Setenv("BUILDKITE_TEST_SPLITTER_CMD", "bin/rspec --options {{testExamples}} --format")
+	defer os.Unsetenv("BUILDKITE_TEST_SPLITTER_CMD")
 
-	gotName, gotArgs := rspec.commandNameAndArgs(testCases, testArgs)
+	gotName, gotArgs := rspec.commandNameAndArgs(testCases)
 
 	wantName := "bin/rspec"
 	wantArgs := []string{"--options", "spec/models/user_spec.rb", "spec/models/billing_spec.rb", "--format"}
@@ -28,9 +29,10 @@ func TestCommandNameAndArgs_WithCommandArgs(t *testing.T) {
 func TestCommandNameAndArgs_WithoutTestPlaceholder(t *testing.T) {
 	rspec := Rspec{}
 	testCases := []string{"spec/models/user_spec.rb", "spec/models/billing_spec.rb"}
-	testArgs := []string{"bin/rspec", "--options", "--format"}
+	os.Setenv("BUILDKITE_TEST_SPLITTER_CMD", "bin/rspec --options --format")
+	defer os.Unsetenv("BUILDKITE_TEST_SPLITTER_CMD")
 
-	gotName, gotArgs := rspec.commandNameAndArgs(testCases, testArgs)
+	gotName, gotArgs := rspec.commandNameAndArgs(testCases)
 
 	wantName := "bin/rspec"
 	wantArgs := []string{"--options", "--format", "spec/models/user_spec.rb", "spec/models/billing_spec.rb"}
@@ -46,9 +48,8 @@ func TestCommandNameAndArgs_WithoutTestPlaceholder(t *testing.T) {
 func TestCommandNameAndArgs_DefaultCommand(t *testing.T) {
 	rspec := Rspec{}
 	testCases := []string{"spec/models/user_spec.rb", "spec/models/billing_spec.rb"}
-	testArgs := []string{}
 
-	gotName, gotArgs := rspec.commandNameAndArgs(testCases, testArgs)
+	gotName, gotArgs := rspec.commandNameAndArgs(testCases)
 
 	wantName := "bundle"
 	wantArgs := []string{"exec", "rspec", "spec/models/user_spec.rb", "spec/models/billing_spec.rb"}

--- a/main.go
+++ b/main.go
@@ -66,7 +66,11 @@ func main() {
 	for _, testCase := range thisNodeTask.Tests.Cases {
 		runnableTests = append(runnableTests, testCase.Path)
 	}
-	cmd := testRunner.Command(runnableTests, cfg.TestCommand)
+
+	cmd, err := testRunner.Command(runnableTests, cfg.TestCommand)
+	if err != nil {
+		log.Fatalf("Couldn't process test command: %q, %v", cfg.TestCommand, err)
+	}
 
 	if err := cmd.Start(); err != nil {
 		log.Fatalf("Couldn't start tests: %v", err)

--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func main() {
 	for _, testCase := range thisNodeTask.Tests.Cases {
 		runnableTests = append(runnableTests, testCase.Path)
 	}
-	cmd := testRunner.Command(runnableTests)
+	cmd := testRunner.Command(runnableTests, cfg.TestCommand)
 
 	if err := cmd.Start(); err != nil {
 		log.Fatalf("Couldn't start tests: %v", err)

--- a/main.go
+++ b/main.go
@@ -24,8 +24,6 @@ import (
 func main() {
 	// TODO: detect test runner and use appropriate runner
 	testRunner := runner.Rspec{}
-	// Get the arguments without the program name
-	argsWithoutProg := os.Args[1:]
 	// Gathering files
 	filesFlag := flag.String("files", "", "string of file names for splitting")
 	flag.Parse()
@@ -68,7 +66,7 @@ func main() {
 	for _, testCase := range thisNodeTask.Tests.Cases {
 		runnableTests = append(runnableTests, testCase.Path)
 	}
-	cmd := testRunner.Command(runnableTests, argsWithoutProg)
+	cmd := testRunner.Command(runnableTests)
 
 	if err := cmd.Start(); err != nil {
 		log.Fatalf("Couldn't start tests: %v", err)

--- a/main.go
+++ b/main.go
@@ -25,6 +25,8 @@ func main() {
 	// TODO: detect test runner and use appropriate runner
 	testRunner := runner.Rspec{}
 
+	argsWithoutProg := os.Args[1:]
+	fmt.Println(argsWithoutProg)
 	// Gathering files
 	filesFlag := flag.String("files", "", "string of file names for splitting")
 	flag.Parse()
@@ -67,7 +69,7 @@ func main() {
 	for _, testCase := range thisNodeTask.Tests.Cases {
 		runnableTests = append(runnableTests, testCase.Path)
 	}
-	cmd := testRunner.Command(runnableTests)
+	cmd := testRunner.Command(runnableTests, argsWithoutProg)
 
 	if err := cmd.Start(); err != nil {
 		log.Fatalf("Couldn't start tests: %v", err)

--- a/main.go
+++ b/main.go
@@ -24,9 +24,8 @@ import (
 func main() {
 	// TODO: detect test runner and use appropriate runner
 	testRunner := runner.Rspec{}
-
+	// Get the arguments without the program name
 	argsWithoutProg := os.Args[1:]
-	fmt.Println(argsWithoutProg)
 	// Gathering files
 	filesFlag := flag.String("files", "", "string of file names for splitting")
 	flag.Parse()


### PR DESCRIPTION
### Description
Currently, the Rspec command that will be executed by the test splitter is hard-coded as: 
`bin/rspec --options rspec.ci $test_files`
This command works well for bk/bk pipeline, however, beta customers might run Rspec with different commands and we should make the command configurable.

**Decisions:**

- We pass the whole test command as a new ENV variable to test-splitter
- We support interpolation of the test examples in the Rspec command. Example:
  
`BUILDKITE_TEST_SPLITTER_CMD=bundle exec rspec {{testExamples}}`

- If no test command is provided to the test-splitter, fallback to `bundle exec rspec $testExamples`


### Context
linear
https://linear.app/buildkite/issue/TAT-94/allow-configuration-of-rspec-command-to-be-executed

basecamp discussion
https://3.basecamp.com/3453178/buckets/33707278/messages/7318595635

### Testing
I tested the change locally. Here are the scenarios.
1. Provide test command without interpolation placeholder
`BUILDKITE_TEST_SPLITTER_CMD='bin/rspec --options rspec.ci' ./test-splitter ` ✅ tests running with customised command

2. Provide test command with interpolation placeholder
BUILDKITE_TEST_SPLITTER_CMD='bin/rspec --options rspec.ci {{testExamples}}' ./test-splitter ✅ tests running with customised command

3. Do not provide test command
./test-splitter ✅ tests running with default test command

4. Provide invalid test command ✅ error is handled 
```
BUILDKITE_TEST_SPLITTER_CMD='bin/rspecabdsdf --options rspec.ci' ./test-splitter
"bin/rspecabdsdf --options rspec.ci spec/features/clusters/sidenav_single_cluster_spec.rb spec/models/billing/plan/features_spec.rb spec/models/scm/pipeline_settings_spec.rb spec/workers/s3_copy_object_worker_spec.rb"
2024/05/01 15:49:01 Couldn't start tests: fork/exec bin/rspecabdsdf: no such file or directory
```
5. Provide invalid test command with single quote  ✅ error is handled 
```
BUILDKITE_TEST_SPLITTER_CMD="bin/rspec --options rspec.ci 'a  {{testExamples}}" ./test-splitter
Couldn't process test command "bin/rspec --options rspec.ci 'a  {{testExamples}}": Unterminated single-quoted string%
```