### PR TITLE
Return specific exit code from Test Splitter Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,9 @@ Otherwise, your script for executing specs may look something like:
 chmod +x test-splitter
 ./test-splitter # fetches the test plan for this node, and then executes the rspec tests
 ```
-
-
+### Exit code
+| Exit code | Description |
+| ---- | ---- |
+| 0 | All tests pass |
+| 1 | At least one test fails |
+| 3 | Test Splitter failure (eg. config error) |


### PR DESCRIPTION
### Description
Currently the test splitter exit with exit code 1 when there's a Rspec test failure. The test splitter also exits with exit code 1 when there are other errors (eg. config error). 

In the bk/bk pipeline setup, we rerun failed tests when the test splitter exits with non-zero exit code. As both Rspec failure and other test splitter failures exit with 1, we can't differentiate them. 

In this PR, the test splitter will return exit code 3 and prints error message if it's not Rspec test failure

### Context
Linear ticket:
https://linear.app/buildkite/issue/TAT-109/return-specific-exit-code-from-test-splitter-client
Additional context on slack:
TLDR: It's suggested we pick a number from 3-31 for the exit code. I checked bk/bk pipeline setup and 3 is not being used
https://buildkite-corp.slack.com/archives/C05NKQQTSGM/p1714633465870209

### Changes
Adding a helper function to print error message and exit with custom exit code



