### PR TITLE
Fix typo and env table in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ The available Go binaries
 |  `BUILDKITE_SPLITTER_IDENTIFIER` | `BUILDKITE_BUILD_ID` | Required, use default unless you have a specific use case |
 | `BUILDKITE_SPLITTER_TEST_FILE_PATTERN` | `spec/**/*_spec.rb` | Optional, glob pattern for discovering test files that need to be executed. </br> *It accepts pattern syntax supported by [zzglob](https://github.com/DrJosh9000/zzglob?tab=readme-ov-file#pattern-syntax) library*. |
 | `BUILDKITE_SPLITTER_TEST_FILE_EXCLUDE_PATTERN` | - | Optional, glob pattern to use for excluding test files or directory. </br> *It accepts pattern syntax supported by [zzglob](https://github.com/DrJosh9000/zzglob?tab=readme-ov-file#pattern-syntax) library.* |
-| `BUILDKITE_TEST_SPLITTER_CMD` | `bundle exec rspec {{testExamples}}` | Optional, test commmand for running your tests. Test splitter will fill in the {{testExamples}} placeholder with the test splitting results |
+| `BUILDKITE_TEST_SPLITTER_CMD` | `bundle exec rspec {{testExamples}}` | Optional, test command for running your tests. Test splitter will fill in the {{testExamples}} placeholder with the test splitting results |
+
 For most use cases, Test Splitter should work out of the box due to the default values available from your Buildkite environment.
 
 However, you'll need to set `BUILDKITE_SPLITTER_SUITE_TOKEN` if your test collector doesn't use the `BUILDKITE_ANALYTICS_TOKEN` value, or your pipeline has multiple suites.


### PR DESCRIPTION
### Description

Fixing typo and env table in the README file

### Context

https://linear.app/buildkite/issue/TAT-141/fix-typo-and-env-table-in-the-readme-file