### PR TITLE
Support exclude pattern that is a specific directory

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,6 @@ require (
 )
 
 require (
-	github.com/DrJosh9000/zzglob v0.1.0
+	github.com/DrJosh9000/zzglob v0.2.0
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/DrJosh9000/zzglob v0.1.0 h1:E/HKiIpoMEduwfn9+3Os8hGsh3JDw0rOnx2xOMNYTwY=
-github.com/DrJosh9000/zzglob v0.1.0/go.mod h1:+iLI/qvROFsS1A/jl+B8MVYNu/0cjveYOJqU37O8fcs=
+github.com/DrJosh9000/zzglob v0.2.0 h1:/emTm1QHFXZZlRark33J8KiHrSNMIXDYXVY0jDjsSa4=
+github.com/DrJosh9000/zzglob v0.2.0/go.mod h1:+iLI/qvROFsS1A/jl+B8MVYNu/0cjveYOJqU37O8fcs=
 github.com/buildkite/roko v1.2.0 h1:hbNURz//dQqNl6Eo9awjQOVOZwSDJ8VEbBDxSfT9rGQ=
 github.com/buildkite/roko v1.2.0/go.mod h1:23R9e6nHxgedznkwwfmqZ6+0VJZJZ2Sg/uVcp2cP46I=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=

--- a/internal/runner/discover.go
+++ b/internal/runner/discover.go
@@ -31,18 +31,24 @@ func discoverTestFiles(pattern DiscoveryPattern) ([]string, error) {
 		if err != nil {
 			fmt.Printf("Error walking: %v\n", err)
 		}
-		if d.IsDir() {
+
+		// Check if the path matches the exclude pattern. If so, skip it.
+		// If it matches a directory, then skip that directory.
+		if parsedExcludePattern.Match(path) {
+			if d.IsDir() {
+				return fs.SkipDir
+			}
 			return nil
 		}
-
-		// Check if the path matches the exclude pattern and skip it
-		if parsedExcludePattern.Match(path) {
+		// Skip directories that happen to match the include pattern - we're
+		// only interested in files.
+		if d.IsDir() {
 			return nil
 		}
 
 		discoveredFiles = append(discoveredFiles, path)
 		return nil
-	}, nil)
+	}, zzglob.WalkIntermediateDirs(true))
 
 	return discoveredFiles, nil
 }

--- a/internal/runner/discover_test.go
+++ b/internal/runner/discover_test.go
@@ -52,3 +52,26 @@ func TestDiscoverTestFiles_WithExcludePattern(t *testing.T) {
 		t.Errorf("discoverTestFiles(%q, %q) diff (-got +want):\n%s", pattern, excludePattern, diff)
 	}
 }
+
+func TestDiscoverTestFiles_WithExcludeDirectory(t *testing.T) {
+	pattern := "fixtures/**/*_test"
+	excludePattern := "fixtures/animals"
+	got, err := discoverTestFiles(DiscoveryPattern{
+		IncludePattern: pattern,
+		ExcludePattern: excludePattern,
+	})
+
+	if err != nil {
+		t.Errorf("discoverTestFiles(%q, %q) error: %v", pattern, excludePattern, err)
+	}
+
+	want := []string{
+		"fixtures/fruits/apple_test",
+		"fixtures/fruits/banana_test",
+		"fixtures/vegetable_test",
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("discoverTestFiles(%q, %q) diff (-got +want):\n%s", pattern, excludePattern, diff)
+	}
+}


### PR DESCRIPTION
### Description

The exclusion pattern can now be a specific directory (or glob that only matches directories).

### Context

Relates to #54 and #46

### Changes

- Update zzglob to v0.2.0 to support new option
- Pass the new option
- Change the callback logic to return `fs.SkipDir` when the exclusion pattern matches a directory
- Add a test

### Testing

See new unit test.
