### PR TITLE
Update IDENTIFIER default to BUILD_ID + STEP_ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ The available Go binaries
 |  `BUILDKITE_PARALLEL_JOB_COUNT` | - | Required, total number of parallelism |
 |  `BUILDKITE_PARALLEL_JOB` | - | Required, test plan for specific node |
 | `BUILDKITE_SPLITTER_SUITE_TOKEN` | `BUILDKITE_ANALYTICS_TOKEN` | Required, unique token for Test Suite that is being parallelised |
-|  `BUILDKITE_SPLITTER_IDENTIFIER` | `BUILDKITE_BUILD_ID/BUILDKITE_STEP_ID` | Required, use default unless you have a specific use case |
+|  `BUILDKITE_SPLITTER_IDENTIFIER` | `BUILDKITE_BUILD_ID/BUILDKITE_STEP_ID` | Optional. Test Splitter uses the identifier to store and fetch the test plan and must be unique for each build and steps group. By default it will use a composite of `BUILDKITE_BUILD_ID` and `BUILDKITE_STEP_ID`, but it can be overridden by specifying the `BUILDKITE_SPLITTER_IDENTIFIER`. `BUILDKITE_BUILD_ID` and `BUILDKITE_STEP_ID` must be accessible by the client when using the default. |
 | `BUILDKITE_SPLITTER_TEST_FILE_PATTERN` | `spec/**/*_spec.rb` | Optional, glob pattern for discovering test files that need to be executed. </br> *It accepts pattern syntax supported by [zzglob](https://github.com/DrJosh9000/zzglob?tab=readme-ov-file#pattern-syntax) library*. |
 | `BUILDKITE_SPLITTER_TEST_FILE_EXCLUDE_PATTERN` | - | Optional, glob pattern to use for excluding test files or directory. </br> *It accepts pattern syntax supported by [zzglob](https://github.com/DrJosh9000/zzglob?tab=readme-ov-file#pattern-syntax) library.* |
-| `BUILDKITE_TEST_SPLITTER_CMD` | `bundle exec rspec {{testExamples}}` | Optional, test command for running your tests. Test splitter will fill in the {{testExamples}} placeholder with the test splitting results |
+| `BUILDKITE_TEST_SPLITTER_CMD` | `bundle exec rspec {{testExamples}}` | Optional, test command for running your tests. Test splitter will fill in the `{{testExamples}}` placeholder with the test splitting results |
 
 For most use cases, Test Splitter should work out of the box due to the default values available from your Buildkite environment.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The available Go binaries
 |  `BUILDKITE_PARALLEL_JOB_COUNT` | - | Required, total number of parallelism |
 |  `BUILDKITE_PARALLEL_JOB` | - | Required, test plan for specific node |
 | `BUILDKITE_SPLITTER_SUITE_TOKEN` | `BUILDKITE_ANALYTICS_TOKEN` | Required, unique token for Test Suite that is being parallelised |
-|  `BUILDKITE_SPLITTER_IDENTIFIER` | `BUILDKITE_BUILD_ID` | Required, use default unless you have a specific use case |
+|  `BUILDKITE_SPLITTER_IDENTIFIER` | `BUILDKITE_BUILD_ID/BUILDKITE_STEP_ID` | Required, use default unless you have a specific use case |
 | `BUILDKITE_SPLITTER_TEST_FILE_PATTERN` | `spec/**/*_spec.rb` | Optional, glob pattern for discovering test files that need to be executed. </br> *It accepts pattern syntax supported by [zzglob](https://github.com/DrJosh9000/zzglob?tab=readme-ov-file#pattern-syntax) library*. |
 | `BUILDKITE_SPLITTER_TEST_FILE_EXCLUDE_PATTERN` | - | Optional, glob pattern to use for excluding test files or directory. </br> *It accepts pattern syntax supported by [zzglob](https://github.com/DrJosh9000/zzglob?tab=readme-ov-file#pattern-syntax) library.* |
 | `BUILDKITE_TEST_SPLITTER_CMD` | `bundle exec rspec {{testExamples}}` | Optional, test command for running your tests. Test splitter will fill in the {{testExamples}} placeholder with the test splitting results |

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -14,7 +14,7 @@ func setEnv(t *testing.T) {
 	os.Setenv("BUILDKITE_PARALLEL_JOB", "7")
 	os.Setenv("BUILDKITE_SPLITTER_BASE_URL", "https://build.kite")
 	os.Setenv("BUILDKITE_SPLITTER_MODE", "static")
-	os.Setenv("BUILDKITE_BUILD_ID", "xyz")
+	os.Setenv("BUILDKITE_SPLITTER_IDENTIFIER", "xyz")
 	os.Setenv("BUILDKITE_SPLITTER_SUITE_TOKEN", "my_token")
 	os.Setenv("BUILDKITE_TEST_SPLITTER_CMD", "bin/rspec {{testExamples}}")
 }

--- a/internal/config/read.go
+++ b/internal/config/read.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 )
@@ -25,7 +26,7 @@ func (c *Config) readFromEnv() error {
 	var errs InvalidConfigError
 
 	c.SuiteToken = getEnvWithDefault("BUILDKITE_SPLITTER_SUITE_TOKEN", os.Getenv("BUILDKITE_ANALYTICS_TOKEN"))
-	c.Identifier = getEnvWithDefault("BUILDKITE_SPLITTER_IDENTIFIER", os.Getenv("BUILDKITE_BUILD_ID"))
+	c.Identifier = getEnvWithDefault("BUILDKITE_SPLITTER_IDENTIFIER", fmt.Sprintf("%s/%s", os.Getenv("BUILDKITE_BUILD_ID"), os.Getenv("BUILDKITE_STEP_ID")))
 	c.ServerBaseUrl = getEnvWithDefault("BUILDKITE_SPLITTER_BASE_URL", "https://buildkite.com")
 	c.Mode = getEnvWithDefault("BUILDKITE_SPLITTER_MODE", "static")
 	c.TestCommand = getEnvWithDefault("BUILDKITE_TEST_SPLITTER_CMD", "bundle exec rspec {{testExamples}}")

--- a/internal/config/read_test.go
+++ b/internal/config/read_test.go
@@ -13,7 +13,7 @@ func TestConfigReadFromEnv(t *testing.T) {
 	os.Setenv("BUILDKITE_PARALLEL_JOB", "0")
 	os.Setenv("BUILDKITE_SPLITTER_BASE_URL", "https://buildkite.localhost")
 	os.Setenv("BUILDKITE_SPLITTER_MODE", "static")
-	os.Setenv("BUILDKITE_BUILD_ID", "123")
+	os.Setenv("BUILDKITE_SPLITTER_IDENTIFIER", "123")
 	os.Setenv("BUILDKITE_SPLITTER_SUITE_TOKEN", "my_token")
 	os.Setenv("BUILDKITE_TEST_SPLITTER_CMD", "bin/rspec {{testExamples}}")
 	defer os.Clearenv()
@@ -44,9 +44,10 @@ func TestConfigReadFromEnv_MissingConfigWithDefault(t *testing.T) {
 	os.Setenv("BUILDKITE_SPLITTER_BASE_URL", "")
 	os.Setenv("BUILDKITE_SPLITTER_MODE", "")
 	os.Setenv("BUILDKITE_TEST_SPLITTER_CMD", "")
-	defer os.Unsetenv("BUILDKITE_SPLITTER_BASE_URL")
-	defer os.Unsetenv("BUILDKITE_SPLITTER_MODE")
-	defer os.Unsetenv("BUILDKITE_TEST_SPLITTER_CMD")
+	os.Setenv("BUILDKITE_SPLITTER_IDENTIFIER", "")
+	os.Setenv("BUILDKITE_BUILD_ID", "123")
+	os.Setenv("BUILDKITE_STEP_ID", "456")
+	defer os.Clearenv()
 
 	c := Config{}
 	c.readFromEnv()
@@ -60,6 +61,10 @@ func TestConfigReadFromEnv_MissingConfigWithDefault(t *testing.T) {
 
 	if c.TestCommand != "bundle exec rspec {{testExamples}}" {
 		t.Errorf("TestCommand = %v, want %v", c.TestCommand, "bundle exec rspec {{testExamples}}")
+	}
+
+	if c.Identifier != "123/456" {
+		t.Errorf("Identifier = %v, want %v", c.Identifier, "123/456")
 	}
 }
 


### PR DESCRIPTION
### Description
Current default BUILDKITE_SPLITTER_IDENTIFIER is the BUILDKITE_BUILD_ID. With this default setup, the test splitter doesn't work correctly when there are multiple test groups in one build. 

For more context: 
A beta customer try to apply different exclude/include patterns at different steps with the same identifier (BUILDKITE_BUILD_ID), and released the exclude/include patterns wasn't applied. This is due to we cache plan for same identifier. https://github.com/buildkite/test-splitter/issues/55

This PR updates the default identifier to BUILDKITE_BUILD_ID/BUILDKITE_STEP_ID, and update the README.

### Context

https://linear.app/buildkite/issue/TAT-138/update-buildkite-splitter-identifier-default-to-build-id-step-id




