### PR TITLE
Refactor API package

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -1,0 +1,17 @@
+package api
+
+type client struct {
+	ServerBaseUrl string
+	AccessToken   string
+}
+
+type ClientConfig struct {
+	ServerBaseUrl string
+	AccessToken   string
+}
+
+func NewClient(cfg ClientConfig) *client {
+	return &client{
+		ServerBaseUrl: cfg.ServerBaseUrl,
+	}
+}

--- a/internal/api/create_test_plan.go
+++ b/internal/api/create_test_plan.go
@@ -27,8 +27,8 @@ type TestPlanParams struct {
 	Tests       plan.Tests `json:"tests"`
 }
 
-// FetchTestPlan fetches a test plan from the service, including retries.
-func FetchTestPlan(ctx context.Context, splitterPath string, params TestPlanParams) (plan.TestPlan, error) {
+// CreateTestPlan creates a test plan from the service, including retries.
+func CreateTestPlan(ctx context.Context, splitterPath string, params TestPlanParams) (plan.TestPlan, error) {
 	// Retry using exponential backoff offerred by roko
 	// https://pkg.go.dev/github.com/buildkite/roko#ExponentialSubsecond
 	//
@@ -53,7 +53,7 @@ func FetchTestPlan(ctx context.Context, splitterPath string, params TestPlanPara
 		roko.WithJitter(),
 	)
 	testPlan, err := roko.DoFunc(ctx, r, func(r *roko.Retrier) (plan.TestPlan, error) {
-		tp, err := tryFetchTestPlan(ctx, splitterPath, params)
+		tp, err := tryCreateTestPlan(ctx, splitterPath, params)
 		// Don't retry if the request was invalid
 		if errors.Is(err, errInvalidRequest) {
 			r.Break()
@@ -64,8 +64,8 @@ func FetchTestPlan(ctx context.Context, splitterPath string, params TestPlanPara
 	return testPlan, err
 }
 
-// tryFetchTestPlan fetches a test plan from the service.
-func tryFetchTestPlan(ctx context.Context, splitterPath string, params TestPlanParams) (plan.TestPlan, error) {
+// tryCreateTestPlan creates a test plan from the service.
+func tryCreateTestPlan(ctx context.Context, splitterPath string, params TestPlanParams) (plan.TestPlan, error) {
 	// convert params to json string
 	requestBody, err := json.Marshal(params)
 	if err != nil {

--- a/internal/api/create_test_plan_test.go
+++ b/internal/api/create_test_plan_test.go
@@ -15,7 +15,7 @@ import (
 
 func ptr[T any](t T) *T { return &t }
 
-func TestFetchTestPlan(t *testing.T) {
+func TestCreateTestPlan(t *testing.T) {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, `{
 	"tasks": {
@@ -39,9 +39,9 @@ func TestFetchTestPlan(t *testing.T) {
 	ctx := context.Background()
 
 	params := TestPlanParams{}
-	got, err := FetchTestPlan(ctx, svr.URL, params)
+	got, err := CreateTestPlan(ctx, svr.URL, params)
 	if err != nil {
-		t.Errorf("FetchTestPlan(%q, %v) error = %v", svr.URL, params, err)
+		t.Errorf("CreateTestPlan(%q, %v) error = %v", svr.URL, params, err)
 	}
 	want := plan.TestPlan{
 		Tasks: map[string]*plan.Task{
@@ -59,11 +59,11 @@ func TestFetchTestPlan(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(got, want); diff != "" {
-		t.Errorf("FetchTestPlan(%q, %v) diff (-got +want):\n%s", svr.URL, params, diff)
+		t.Errorf("CreateTestPlan(%q, %v) diff (-got +want):\n%s", svr.URL, params, diff)
 	}
 }
 
-func TestFetchTestPlan_Error4xx(t *testing.T) {
+func TestCreateTestPlan_Error4xx(t *testing.T) {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(400)
 	}))
@@ -71,21 +71,21 @@ func TestFetchTestPlan_Error4xx(t *testing.T) {
 
 	ctx := context.Background()
 	params := TestPlanParams{}
-	got, err := FetchTestPlan(ctx, svr.URL, params)
+	got, err := CreateTestPlan(ctx, svr.URL, params)
 
 	wantTestPlan := plan.TestPlan{}
 
 	if diff := cmp.Diff(got, wantTestPlan); diff != "" {
-		t.Errorf("FetchTestPlan(%q, %v) diff (-got +want):\n%s", svr.URL, params, diff)
+		t.Errorf("CreateTestPlan(%q, %v) diff (-got +want):\n%s", svr.URL, params, diff)
 	}
 
 	if !errors.Is(err, errInvalidRequest) {
-		t.Errorf("FetchTestPlan(%q, %v) want %v got %v", svr.URL, params, errInvalidRequest, err)
+		t.Errorf("CreateTestPlan(%q, %v) want %v got %v", svr.URL, params, errInvalidRequest, err)
 	}
 }
 
 // Test the client keeps getting 5xx error until reached context deadline
-func TestFetchTestPlan_Timeout(t *testing.T) {
+func TestCreateTestPlan_Timeout(t *testing.T) {
 
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(500)
@@ -97,12 +97,12 @@ func TestFetchTestPlan_Timeout(t *testing.T) {
 	defer cancel()
 
 	params := TestPlanParams{}
-	got, err := FetchTestPlan(fetchCtx, svr.URL, params)
+	got, err := CreateTestPlan(fetchCtx, svr.URL, params)
 
 	wantTestPlan := plan.TestPlan{}
 
 	if diff := cmp.Diff(got, wantTestPlan); diff != "" {
-		t.Errorf("FetchTestPlan(%q, %v) diff (-got +want):\n%s", svr.URL, params, diff)
+		t.Errorf("CreateTestPlan(%q, %v) diff (-got +want):\n%s", svr.URL, params, diff)
 	}
 
 	if !errors.Is(err, context.DeadlineExceeded) {

--- a/internal/api/create_test_plan_test.go
+++ b/internal/api/create_test_plan_test.go
@@ -39,9 +39,12 @@ func TestCreateTestPlan(t *testing.T) {
 	ctx := context.Background()
 
 	params := TestPlanParams{}
-	got, err := CreateTestPlan(ctx, svr.URL, params)
+	apiClient := client{
+		ServerBaseUrl: svr.URL,
+	}
+	got, err := apiClient.CreateTestPlan(ctx, params)
 	if err != nil {
-		t.Errorf("CreateTestPlan(%q, %v) error = %v", svr.URL, params, err)
+		t.Errorf("CreateTestPlan(ctx, %v) error = %v", params, err)
 	}
 	want := plan.TestPlan{
 		Tasks: map[string]*plan.Task{
@@ -59,7 +62,7 @@ func TestCreateTestPlan(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(got, want); diff != "" {
-		t.Errorf("CreateTestPlan(%q, %v) diff (-got +want):\n%s", svr.URL, params, diff)
+		t.Errorf("CreateTestPlan(ctx, %v) diff (-got +want):\n%s", params, diff)
 	}
 }
 
@@ -71,16 +74,20 @@ func TestCreateTestPlan_Error4xx(t *testing.T) {
 
 	ctx := context.Background()
 	params := TestPlanParams{}
-	got, err := CreateTestPlan(ctx, svr.URL, params)
+	apiClient := client{
+		ServerBaseUrl: svr.URL,
+	}
+
+	got, err := apiClient.CreateTestPlan(ctx, params)
 
 	wantTestPlan := plan.TestPlan{}
 
 	if diff := cmp.Diff(got, wantTestPlan); diff != "" {
-		t.Errorf("CreateTestPlan(%q, %v) diff (-got +want):\n%s", svr.URL, params, diff)
+		t.Errorf("CreateTestPlan(ctx, %v) diff (-got +want):\n%s", params, diff)
 	}
 
 	if !errors.Is(err, errInvalidRequest) {
-		t.Errorf("CreateTestPlan(%q, %v) want %v got %v", svr.URL, params, errInvalidRequest, err)
+		t.Errorf("CreateTestPlan(ctx, %v) want %v got %v", params, errInvalidRequest, err)
 	}
 }
 
@@ -97,15 +104,19 @@ func TestCreateTestPlan_Timeout(t *testing.T) {
 	defer cancel()
 
 	params := TestPlanParams{}
-	got, err := CreateTestPlan(fetchCtx, svr.URL, params)
+	apiClient := client{
+		ServerBaseUrl: svr.URL,
+	}
+
+	got, err := apiClient.CreateTestPlan(fetchCtx, params)
 
 	wantTestPlan := plan.TestPlan{}
 
 	if diff := cmp.Diff(got, wantTestPlan); diff != "" {
-		t.Errorf("CreateTestPlan(%q, %v) diff (-got +want):\n%s", svr.URL, params, diff)
+		t.Errorf("CreateTestPlan(ctx, %v) diff (-got +want):\n%s", params, diff)
 	}
 
 	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Errorf("FetchTestPlan(%q, %v) want %v, got %v", svr.URL, params, context.DeadlineExceeded, err)
+		t.Errorf("FetchTestPlan(ctx, %v) want %v, got %v", params, context.DeadlineExceeded, err)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -135,7 +135,11 @@ func fetchOrCreateTestPlan(ctx context.Context, cfg config.Config, files []strin
 		Format: "files",
 	}
 
-	testPlan, err := api.CreateTestPlan(ctx, cfg.ServerBaseUrl, api.TestPlanParams{
+	apiClient := api.NewClient(api.ClientConfig{
+		ServerBaseUrl: cfg.ServerBaseUrl,
+	})
+
+	testPlan, err := apiClient.CreateTestPlan(ctx, api.TestPlanParams{
 		SuiteToken:  cfg.SuiteToken,
 		Mode:        cfg.Mode,
 		Identifier:  cfg.Identifier,

--- a/main.go
+++ b/main.go
@@ -135,7 +135,7 @@ func fetchOrCreateTestPlan(ctx context.Context, cfg config.Config, files []strin
 		Format: "files",
 	}
 
-	testPlan, err := api.FetchTestPlan(ctx, cfg.ServerBaseUrl, api.TestPlanParams{
+	testPlan, err := api.CreateTestPlan(ctx, cfg.ServerBaseUrl, api.TestPlanParams{
 		SuiteToken:  cfg.SuiteToken,
 		Mode:        cfg.Mode,
 		Identifier:  cfg.Identifier,


### PR DESCRIPTION
### Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->
We will be implementing split by example that includes a change on how the client communicate with the server.
With the new changes, the client will call the server's new endpoint to fetch the test plan first, and make a subsequent request to create a test plan if the test plan hasn't been created. The pseudocode for the changes looks something like this:

```
// main.go
func fetchOrCreatePlan() {
  plan := api.FetchPlan()

  if plan != nil {
    return plan
  }

  params := buildParamsToCreatePlan()

  plan := api.CreatePlan(params)

  if plan != nil {
    return plan
  }
}
```

Currently, we have `FetchTestPlan` function in the `api` package that creates the test plan. Since we want to handle fetch and create separately, we need to rename the existing function into `CreateTestPlan`. Also, because fetch and create function will share the same concerns (e.g. url, token, organization slug), I created a `client` struct in the `api` that will hold the information so we don't need to pass it twice.

This PR is a prep for further work to separate fetch and create of test plan.

### Context

<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->
https://linear.app/buildkite/issue/TAT-143/fetch-plan-from-the-cache-before-making-a-post-request-to-create-one

### Changes

<!--
List of what the PR changes.

Can skip if changes are simple or clear from the commit messages.
-->
- Rename `FetchTestPlan` to `CreateTestPlan`
- Create `client` struct
- Move `FetchTestPlan` into a function for the `client` struct



