### PR TITLE
Update test splitter internal error exit code and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,4 +46,5 @@ chmod +x test-splitter
 | ---- | ---- |
 | 0 | All tests pass |
 | 1 | At least one test fails |
-| 3 | Test Splitter failure (eg. config error) |
+| 16 | Test Splitter failure (eg. config error) |
+| * | Test Splitter failure (eg. config error) |

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ chmod +x test-splitter
 ### Exit code
 | Exit code | Description |
 | ---- | ---- |
-| 0 | All tests pass |
-| 1 | At least one test fails |
+| 0 | Success (passed through from test runner) |
+| 1 | Failure (passed through from test runner) |
 | 16 | Test Splitter failure (eg. config error) |
-| * | Test Splitter failure (eg. config error) |
+| * | Other errors (passed through from the test runner) |

--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ func main() {
 	} else {
 		fs, err := testRunner.GetFiles()
 		if err != nil {
-			logErrorAndExit(3, "Couldn't get files: %v", err)
+			logErrorAndExit(16, "Couldn't get files: %v", err)
 		}
 		files = fs
 	}
@@ -42,7 +42,7 @@ func main() {
 	// get config
 	cfg, err := config.New()
 	if err != nil {
-		logErrorAndExit(3, "Invalid configuration: %v", err)
+		logErrorAndExit(16, "Invalid configuration: %v", err)
 	}
 
 	// get plan
@@ -54,7 +54,7 @@ func main() {
 
 	testPlan, err := fetchOrCreateTestPlan(fetchCtx, cfg, files)
 	if err != nil {
-		logErrorAndExit(3, "Couldn't create test plan: %v", err)
+		logErrorAndExit(16, "Couldn't create test plan: %v", err)
 	}
 
 	// get plan for this node
@@ -68,11 +68,11 @@ func main() {
 
 	cmd, err := testRunner.Command(runnableTests, cfg.TestCommand)
 	if err != nil {
-		logErrorAndExit(3, "Couldn't process test command: %q, %v", cfg.TestCommand, err)
+		logErrorAndExit(16, "Couldn't process test command: %q, %v", cfg.TestCommand, err)
 	}
 
 	if err := cmd.Start(); err != nil {
-		logErrorAndExit(3, "Couldn't start tests: %v", err)
+		logErrorAndExit(16, "Couldn't start tests: %v", err)
 	}
 
 	// Create a channel that will be closed when the command finishes.
@@ -107,7 +107,7 @@ func main() {
 			exitCode := exitError.ExitCode()
 			logErrorAndExit(exitCode, "Rspec exited with error %d", err)
 		}
-		logErrorAndExit(3, "Couldn't run tests: %v", err)
+		logErrorAndExit(16, "Couldn't run tests: %v", err)
 	}
 
 	// Close the channel that will stop the goroutine.


### PR DESCRIPTION
### Description

This PR updates the exit code for internal failure to 16 as it's suggested in the [PR comment ](https://github.com/buildkite/test-splitter/pull/53#discussion_r1597823888) that we reserve a range of exit codes for internal errors (eg. 16-23). 
This PR also updates the README file to be more clear about where the exit codes coming from. 

### Context

PR comment: https://github.com/buildkite/test-splitter/pull/53#discussion_r1597823888
Linear ticket: https://linear.app/buildkite/issue/TAT-135/document-test-splitter-exit-scenarios-in-readme





