### PR TITLE
Use new API endpoint to fetch and create the test plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ The available Go binaries
 
 | Environment Variable | Default Value | Description |
 | ---- | ---- | ----------- |
-| `BUILDKITE_API_ACCESS_TOKEN ` | - | Required, Buildkite API access token with `read_suites`, `read_test_plan`, and `write_test_plan` scopes. |
-| `BUILDKITE_ORGANIZATION_SLUG` | - | Required, the slug of your Buildkite organization. |
+| `BUILDKITE_API_ACCESS_TOKEN ` | - | Required, Buildkite API access token with `read_suites`, `read_test_plan`, and `write_test_plan` scopes. You can create access token from [Personal Settings](https://buildkite.com/user/api-access-tokens) in Buildkite |
+| `BUILDKITE_ORGANIZATION_SLUG` | - | Required, the slug of your Buildkite organization. This is available in your pipeline environment, so you don't need to set it manually |
 | `BUILDKITE_PARALLEL_JOB_COUNT` | - | Required, total number of parallelism. |
 | `BUILDKITE_PARALLEL_JOB` | - | Required, test plan for specific node |
 | `BUILDKITE_SPLITTER_IDENTIFIER` | `BUILDKITE_BUILD_ID/BUILDKITE_STEP_ID` | Optional. Test Splitter uses the identifier to store and fetch the test plan and must be unique for each build and steps group. By default it will use a composite of `BUILDKITE_BUILD_ID` and `BUILDKITE_STEP_ID`, but it can be overridden by specifying the `BUILDKITE_SPLITTER_IDENTIFIER`. `BUILDKITE_BUILD_ID` and `BUILDKITE_STEP_ID` must be accessible by the client when using the default. |

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The available Go binaries
 
 For most use cases, Test Splitter should work out of the box due to the default values available from your Buildkite environment.
 
-However, you'll need to set `BUILDKITE_SPLITTER_SUITE_TOKEN` if your test collector doesn't use the `BUILDKITE_ANALYTICS_TOKEN` value, or your pipeline has multiple suites.
+However, you'll have to set `BUILDKITE_API_ACCESS_TOKEN` and `BUILDKITE_SPLITTER_SUITE_SLUG`.
 
 You can also set the `BUILDKITE_SPLITTER_TEST_FILE_PATTERN` or `BUILDKITE_SPLITTER_TEST_FILE_EXCLUDE_PATTERN` if you need to filter the tests selected for execution.
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,14 @@ The available Go binaries
 
 | Environment Variable | Default Value | Description |
 | ---- | ---- | ----------- |
-|  `BUILDKITE_PARALLEL_JOB_COUNT` | - | Required, total number of parallelism |
-|  `BUILDKITE_PARALLEL_JOB` | - | Required, test plan for specific node |
-| `BUILDKITE_SPLITTER_SUITE_TOKEN` | `BUILDKITE_ANALYTICS_TOKEN` | Required, unique token for Test Suite that is being parallelised |
-|  `BUILDKITE_SPLITTER_IDENTIFIER` | `BUILDKITE_BUILD_ID/BUILDKITE_STEP_ID` | Optional. Test Splitter uses the identifier to store and fetch the test plan and must be unique for each build and steps group. By default it will use a composite of `BUILDKITE_BUILD_ID` and `BUILDKITE_STEP_ID`, but it can be overridden by specifying the `BUILDKITE_SPLITTER_IDENTIFIER`. `BUILDKITE_BUILD_ID` and `BUILDKITE_STEP_ID` must be accessible by the client when using the default. |
+| `BUILDKITE_API_ACCESS_TOKEN ` | - | Required, Buildkite API access token with `read_suites`, `read_test_plan`, and `write_test_plan` scopes. |
+| `BUILDKITE_ORGANIZATION_SLUG` | - | Required, the slug of your Buildkite organization. |
+| `BUILDKITE_PARALLEL_JOB_COUNT` | - | Required, total number of parallelism. |
+| `BUILDKITE_PARALLEL_JOB` | - | Required, test plan for specific node |
+| `BUILDKITE_SPLITTER_IDENTIFIER` | `BUILDKITE_BUILD_ID/BUILDKITE_STEP_ID` | Optional. Test Splitter uses the identifier to store and fetch the test plan and must be unique for each build and steps group. By default it will use a composite of `BUILDKITE_BUILD_ID` and `BUILDKITE_STEP_ID`, but it can be overridden by specifying the `BUILDKITE_SPLITTER_IDENTIFIER`. `BUILDKITE_BUILD_ID` and `BUILDKITE_STEP_ID` must be accessible by the client when using the default. |
 | `BUILDKITE_SPLITTER_TEST_FILE_PATTERN` | `spec/**/*_spec.rb` | Optional, glob pattern for discovering test files that need to be executed. </br> *It accepts pattern syntax supported by [zzglob](https://github.com/DrJosh9000/zzglob?tab=readme-ov-file#pattern-syntax) library*. |
 | `BUILDKITE_SPLITTER_TEST_FILE_EXCLUDE_PATTERN` | - | Optional, glob pattern to use for excluding test files or directory. </br> *It accepts pattern syntax supported by [zzglob](https://github.com/DrJosh9000/zzglob?tab=readme-ov-file#pattern-syntax) library.* |
+| `BUILDKITE_SPLITTER_SUITE_SLUG` | - | Required, the slug of your test suite. |
 | `BUILDKITE_TEST_SPLITTER_CMD` | `bundle exec rspec {{testExamples}}` | Optional, test command for running your tests. Test splitter will fill in the `{{testExamples}}` placeholder with the test splitting results |
 
 For most use cases, Test Splitter should work out of the box due to the default values available from your Buildkite environment.

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -1,17 +1,42 @@
 package api
 
+import (
+	"net/http"
+)
+
 type client struct {
-	ServerBaseUrl string
-	AccessToken   string
+	OrganizationSlug string
+	ServerBaseUrl    string
+	AccessToken      string
+	httpClient       *http.Client
 }
 
 type ClientConfig struct {
-	ServerBaseUrl string
-	AccessToken   string
+	AccessToken      string
+	OrganizationSlug string
+	ServerBaseUrl    string
+}
+
+type authTransport struct {
+	accessToken string
+}
+
+func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set("Authorization", "Bearer "+t.accessToken)
+	return http.DefaultTransport.RoundTrip(req)
 }
 
 func NewClient(cfg ClientConfig) *client {
+	httpClient := &http.Client{
+		Transport: &authTransport{
+			accessToken: cfg.AccessToken,
+		},
+	}
+
 	return &client{
-		ServerBaseUrl: cfg.ServerBaseUrl,
+		OrganizationSlug: cfg.OrganizationSlug,
+		AccessToken:      cfg.AccessToken,
+		ServerBaseUrl:    cfg.ServerBaseUrl,
+		httpClient:       httpClient,
 	}
 }

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -4,28 +4,34 @@ import (
 	"net/http"
 )
 
+// client is a client for the test splitter API.
+// It contains the organization slug, server base URL, and an HTTP client.
 type client struct {
 	OrganizationSlug string
 	ServerBaseUrl    string
-	AccessToken      string
 	httpClient       *http.Client
 }
 
+// ClientConfig is the configuration for the test splitter API client.
 type ClientConfig struct {
 	AccessToken      string
 	OrganizationSlug string
 	ServerBaseUrl    string
 }
 
+// authTransport is a middleware for the HTTP client.
 type authTransport struct {
 	accessToken string
 }
 
+// RoundTrip adds the Authorization header to all requests made by the HTTP client.
 func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req.Header.Set("Authorization", "Bearer "+t.accessToken)
 	return http.DefaultTransport.RoundTrip(req)
 }
 
+// NewClient creates a new client for the test splitter API with the given configuration.
+// It also creates an HTTP client with an authTransport middleware.
 func NewClient(cfg ClientConfig) *client {
 	httpClient := &http.Client{
 		Transport: &authTransport{
@@ -35,7 +41,6 @@ func NewClient(cfg ClientConfig) *client {
 
 	return &client{
 		OrganizationSlug: cfg.OrganizationSlug,
-		AccessToken:      cfg.AccessToken,
 		ServerBaseUrl:    cfg.ServerBaseUrl,
 		httpClient:       httpClient,
 	}

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -1,0 +1,53 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNewClient(t *testing.T) {
+	// Create a new client with the given configuration.
+	cfg := ClientConfig{
+		AccessToken:      "asdf1234",
+		OrganizationSlug: "my-org",
+		ServerBaseUrl:    "http://example.com",
+	}
+	c := NewClient(cfg)
+
+	// Check if the client has the correct organization slug.
+	if c.OrganizationSlug != cfg.OrganizationSlug {
+		t.Errorf("NewClient() = %v, want %v", c.OrganizationSlug, cfg.OrganizationSlug)
+	}
+
+	// Check if the client has the correct server base URL.
+	if c.ServerBaseUrl != cfg.ServerBaseUrl {
+		t.Errorf("NewClient() = %v, want %v", c.ServerBaseUrl, cfg.ServerBaseUrl)
+	}
+
+	// Check if the client has an HTTP client.
+	if c.httpClient == nil {
+		t.Errorf("NewClient() = nil, want not nil")
+	}
+}
+
+func TestHttpClient_AttachAccessTokenToRequest(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer svr.Close()
+
+	// Create a new client with the given configuration.
+	cfg := ClientConfig{
+		AccessToken:      "asdf1234",
+		OrganizationSlug: "my-org",
+		ServerBaseUrl:    svr.URL,
+	}
+
+	c := NewClient(cfg)
+	resp, _ := c.httpClient.Get(svr.URL)
+
+	if resp.Request.Header.Get("Authorization") != "Bearer asdf1234" {
+		t.Errorf("Request Authorization header = %v, want %v", resp.Request.Header.Get("Authorization"), "Bearer asdf1234")
+	}
+}

--- a/internal/api/create_test_plan.go
+++ b/internal/api/create_test_plan.go
@@ -28,7 +28,7 @@ type TestPlanParams struct {
 }
 
 // CreateTestPlan creates a test plan from the service, including retries.
-func (c client) CreateTestPlan(ctx context.Context, params TestPlanParams) (plan.TestPlan, error) {
+func (c client) CreateTestPlan(ctx context.Context, suiteSlug string, params TestPlanParams) (plan.TestPlan, error) {
 	// Retry using exponential backoff offerred by roko
 	// https://pkg.go.dev/github.com/buildkite/roko#ExponentialSubsecond
 	//
@@ -53,7 +53,7 @@ func (c client) CreateTestPlan(ctx context.Context, params TestPlanParams) (plan
 		roko.WithJitter(),
 	)
 	testPlan, err := roko.DoFunc(ctx, r, func(r *roko.Retrier) (plan.TestPlan, error) {
-		tp, err := c.tryCreateTestPlan(ctx, params)
+		tp, err := c.tryCreateTestPlan(ctx, suiteSlug, params)
 		// Don't retry if the request was invalid
 		if errors.Is(err, errInvalidRequest) {
 			r.Break()
@@ -65,7 +65,7 @@ func (c client) CreateTestPlan(ctx context.Context, params TestPlanParams) (plan
 }
 
 // tryCreateTestPlan creates a test plan from the service.
-func (c client) tryCreateTestPlan(ctx context.Context, params TestPlanParams) (plan.TestPlan, error) {
+func (c client) tryCreateTestPlan(ctx context.Context, suiteSlug string, params TestPlanParams) (plan.TestPlan, error) {
 	// convert params to json string
 	requestBody, err := json.Marshal(params)
 	if err != nil {
@@ -77,7 +77,7 @@ func (c client) tryCreateTestPlan(ctx context.Context, params TestPlanParams) (p
 	defer cancel()
 
 	// create request
-	postUrl := c.ServerBaseUrl + "/test-splitting/plan"
+	postUrl := fmt.Sprintf("%s/v2/analytics/organizations/%s/suites/%s/test_plan", c.ServerBaseUrl, c.OrganizationSlug, suiteSlug)
 	r, err := http.NewRequestWithContext(reqCtx, "POST", postUrl, bytes.NewBuffer(requestBody))
 	if err != nil {
 		return plan.TestPlan{}, fmt.Errorf("creating request: %w", err)
@@ -85,8 +85,7 @@ func (c client) tryCreateTestPlan(ctx context.Context, params TestPlanParams) (p
 	r.Header.Add("Content-Type", "application/json")
 
 	// send request
-	client := &http.Client{}
-	resp, err := client.Do(r)
+	resp, err := c.httpClient.Do(r)
 	if err != nil {
 		return plan.TestPlan{}, fmt.Errorf("sending request: %w", err)
 	}

--- a/internal/api/create_test_plan.go
+++ b/internal/api/create_test_plan.go
@@ -20,7 +20,6 @@ var (
 
 // TestPlanParams represents the config params sent when fetching a test plan.
 type TestPlanParams struct {
-	SuiteToken  string     `json:"suite_token"`
 	Mode        string     `json:"mode"`
 	Identifier  string     `json:"identifier"`
 	Parallelism int        `json:"parallelism"`

--- a/internal/api/create_test_plan_test.go
+++ b/internal/api/create_test_plan_test.go
@@ -39,10 +39,10 @@ func TestCreateTestPlan(t *testing.T) {
 	ctx := context.Background()
 
 	params := TestPlanParams{}
-	apiClient := client{
+	apiClient := NewClient(ClientConfig{
 		ServerBaseUrl: svr.URL,
-	}
-	got, err := apiClient.CreateTestPlan(ctx, params)
+	})
+	got, err := apiClient.CreateTestPlan(ctx, "my-suite", params)
 	if err != nil {
 		t.Errorf("CreateTestPlan(ctx, %v) error = %v", params, err)
 	}
@@ -74,11 +74,11 @@ func TestCreateTestPlan_Error4xx(t *testing.T) {
 
 	ctx := context.Background()
 	params := TestPlanParams{}
-	apiClient := client{
+	apiClient := NewClient(ClientConfig{
 		ServerBaseUrl: svr.URL,
-	}
+	})
 
-	got, err := apiClient.CreateTestPlan(ctx, params)
+	got, err := apiClient.CreateTestPlan(ctx, "my-suite", params)
 
 	wantTestPlan := plan.TestPlan{}
 
@@ -104,11 +104,11 @@ func TestCreateTestPlan_Timeout(t *testing.T) {
 	defer cancel()
 
 	params := TestPlanParams{}
-	apiClient := client{
+	apiClient := NewClient(ClientConfig{
 		ServerBaseUrl: svr.URL,
-	}
+	})
 
-	got, err := apiClient.CreateTestPlan(fetchCtx, params)
+	got, err := apiClient.CreateTestPlan(fetchCtx, "my-suite", params)
 
 	wantTestPlan := plan.TestPlan{}
 

--- a/internal/api/fetch_test_plan.go
+++ b/internal/api/fetch_test_plan.go
@@ -4,11 +4,19 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 
 	"github.com/buildkite/test-splitter/internal/plan"
 )
 
 // FetchTestPlan fetchs a test plan from the server's cache.
+// If the test plan is found in the cache, it is returned, otherwise nil is returned.
+// Error is returned if there is a client side failure or the server returns a 401.
+// Other server errors are ignored and treated as cache miss.
+//
+// Note: we could ignore all server errors and treat them as a cache miss,
+// but there is no reason to continue the process if the client is unauthorized,
+// so we treat 401 as an error.
 func (c client) FetchTestPlan(suiteSlug string, identifier string) (*plan.TestPlan, error) {
 	url := fmt.Sprintf("%s/v2/analytics/organizations/%s/suites/%s/test_plan?identifier=%s", c.ServerBaseUrl, c.OrganizationSlug, suiteSlug, identifier)
 
@@ -18,6 +26,17 @@ func (c client) FetchTestPlan(suiteSlug string, identifier string) (*plan.TestPl
 		return nil, fmt.Errorf("sending request: %w", err)
 	}
 	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		// happy path
+	case http.StatusUnauthorized:
+		// treat as error
+		return nil, fmt.Errorf("unauthorized: %w", err)
+	default:
+		// ignore other errors and treat them as cache miss
+		return nil, nil
+	}
 
 	// read response
 	responseBody, err := io.ReadAll(resp.Body)

--- a/internal/api/fetch_test_plan.go
+++ b/internal/api/fetch_test_plan.go
@@ -13,10 +13,10 @@ type errorResponse struct {
 	Message string `json:"message"`
 }
 
-// FetchTestPlan fetchs a test plan from the server's cache.
-// If the test plan is found in the cache, it is returned, otherwise nil is returned.
-// Error is returned if there is a client side failure or request is invalid (400 - 403).
-// Other server errors are ignored and treated as cache miss.
+// FetchTestPlan fetchs a test plan from the server.
+// If the plan is found, it returns the plan, otherwise it returns nil.
+// Error is returned if there is a client side failure or invalid request (400, 401, 403).
+// Other server errors are ignored and treated as "not found".
 func (c client) FetchTestPlan(suiteSlug string, identifier string) (*plan.TestPlan, error) {
 	url := fmt.Sprintf("%s/v2/analytics/organizations/%s/suites/%s/test_plan?identifier=%s", c.ServerBaseUrl, c.OrganizationSlug, suiteSlug, identifier)
 
@@ -27,17 +27,20 @@ func (c client) FetchTestPlan(suiteSlug string, identifier string) (*plan.TestPl
 	}
 	defer resp.Body.Close()
 
-	switch {
-	case resp.StatusCode == http.StatusOK:
+	switch resp.StatusCode {
+	case http.StatusOK:
 		// happy path
-	case resp.StatusCode >= 400 && resp.StatusCode <= 403:
-		// treat 400-403 as an error because the request is invalid
+	case http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden:
+		// treat following errors as client side errors because they are not recoverable.
+		// 400: Bad request (invalid request)
+		// 401: Unauthorized (invalid access token)
+		// 403: Forbidden (access token does not have required permissions)
 		responseBody, _ := io.ReadAll(resp.Body)
 		var errorResp errorResponse
 		json.Unmarshal(responseBody, &errorResp)
 		return nil, fmt.Errorf(errorResp.Message)
 	default:
-		// ignore other errors and treat them as cache miss
+		// ignore other errors and treat them as "not found", so the client can proceed with creating a new plan.
 		return nil, nil
 	}
 

--- a/internal/api/fetch_test_plan.go
+++ b/internal/api/fetch_test_plan.go
@@ -1,0 +1,36 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/buildkite/test-splitter/internal/plan"
+)
+
+// FetchTestPlan fetchs a test plan from the server's cache.
+func (c client) FetchTestPlan(suiteSlug string, identifier string) (*plan.TestPlan, error) {
+	url := fmt.Sprintf("%s/v2/analytics/organizations/%s/suites/%s/test_plan?identifier=%s", c.ServerBaseUrl, c.OrganizationSlug, suiteSlug, identifier)
+
+	// send request
+	resp, err := c.httpClient.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("sending request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// read response
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response body: %w", err)
+	}
+
+	// parse response
+	var testPlan plan.TestPlan
+	err = json.Unmarshal(responseBody, &testPlan)
+	if err != nil {
+		return nil, fmt.Errorf("parsing response: %w", err)
+	}
+
+	return &testPlan, nil
+}

--- a/internal/api/fetch_test_plan_test.go
+++ b/internal/api/fetch_test_plan_test.go
@@ -86,27 +86,33 @@ func TestFetchTestPlan_NotFound(t *testing.T) {
 	}
 }
 
-func TestFetchTestPlan_Unauthorized(t *testing.T) {
-	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusUnauthorized)
-	}))
-	defer svr.Close()
+func TestFetchTestPlan_InvalidRequest(t *testing.T) {
+	statusCodes := []int{http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden}
 
-	cfg := ClientConfig{
-		AccessToken:      "asdf1234",
-		OrganizationSlug: "my-org",
-		ServerBaseUrl:    svr.URL,
-	}
+	for _, code := range statusCodes {
+		t.Run(fmt.Sprintf("status code %d", code), func(t *testing.T) {
+			svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(code)
+			}))
+			defer svr.Close()
 
-	c := NewClient(cfg)
-	got, err := c.FetchTestPlan("my-suite", "xyz")
+			cfg := ClientConfig{
+				AccessToken:      "asdf1234",
+				OrganizationSlug: "my-org",
+				ServerBaseUrl:    svr.URL,
+			}
 
-	if err == nil {
-		t.Errorf("FetchTestPlan() want error, got nil")
-	}
+			c := NewClient(cfg)
+			got, err := c.FetchTestPlan("my-suite", "xyz")
 
-	if got != nil {
-		t.Errorf("FetchTestPlan() = %v, want nil", got)
+			if err == nil {
+				t.Errorf("FetchTestPlan() want error, got nil")
+			}
+
+			if got != nil {
+				t.Errorf("FetchTestPlan() = %v, want nil", got)
+			}
+		})
 	}
 }
 

--- a/internal/api/fetch_test_plan_test.go
+++ b/internal/api/fetch_test_plan_test.go
@@ -1,0 +1,135 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/buildkite/test-splitter/internal/plan"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestFetchTestPlan(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{
+	"tasks": {
+		"task_1": {
+			"node_number": 1,
+			"tests": {
+				"cases": [
+					{
+						"path": "hello_world_spec.rb"
+					}
+				],
+				"format": "files"
+			}
+		}
+	}
+}`)
+	}))
+	defer svr.Close()
+
+	cfg := ClientConfig{
+		AccessToken:      "asdf1234",
+		OrganizationSlug: "my-org",
+		ServerBaseUrl:    svr.URL,
+	}
+
+	c := NewClient(cfg)
+	got, err := c.FetchTestPlan("my-suite", "xyz")
+
+	want := plan.TestPlan{
+		Tasks: map[string]*plan.Task{
+			"task_1": {
+				NodeNumber: 1,
+				Tests: plan.Tests{
+					Cases: []plan.TestCase{{
+						Path: "hello_world_spec.rb",
+					}},
+					Format: "files",
+				},
+			},
+		},
+	}
+
+	if err != nil {
+		t.Errorf("FetchTestPlan() error = %v", err)
+	}
+
+	if diff := cmp.Diff(got, &want); diff != "" {
+		t.Errorf("FetchTestPlan() diff (-got +want):\n%s", diff)
+	}
+}
+
+func TestFetchTestPlan_NotFound(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer svr.Close()
+
+	cfg := ClientConfig{
+		AccessToken:      "asdf1234",
+		OrganizationSlug: "my-org",
+		ServerBaseUrl:    svr.URL,
+	}
+
+	c := NewClient(cfg)
+	got, err := c.FetchTestPlan("my-suite", "xyz")
+
+	if err != nil {
+		t.Errorf("FetchTestPlan() error = %v", err)
+	}
+
+	if got != nil {
+		t.Errorf("FetchTestPlan() = %v, want nil", got)
+	}
+}
+
+func TestFetchTestPlan_Unauthorized(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer svr.Close()
+
+	cfg := ClientConfig{
+		AccessToken:      "asdf1234",
+		OrganizationSlug: "my-org",
+		ServerBaseUrl:    svr.URL,
+	}
+
+	c := NewClient(cfg)
+	got, err := c.FetchTestPlan("my-suite", "xyz")
+
+	if err == nil {
+		t.Errorf("FetchTestPlan() want error, got nil")
+	}
+
+	if got != nil {
+		t.Errorf("FetchTestPlan() = %v, want nil", got)
+	}
+}
+
+func TestFetchTestPlan_ServerError(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer svr.Close()
+
+	cfg := ClientConfig{
+		AccessToken:      "asdf1234",
+		OrganizationSlug: "my-org",
+		ServerBaseUrl:    svr.URL,
+	}
+
+	c := NewClient(cfg)
+	got, err := c.FetchTestPlan("my-suite", "xyz")
+
+	if err != nil {
+		t.Errorf("FetchTestPlan() error = %v", err)
+	}
+
+	if got != nil {
+		t.Errorf("FetchTestPlan() = %v, want nil", got)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,8 +18,6 @@ type Config struct {
 	ServerBaseUrl string
 	// SuiteSlug is the slug of the suite.
 	SuiteSlug string
-	// SuiteToken is the token of the test suite.
-	SuiteToken string
 	// TestCommand is the command to run the tests.
 	TestCommand string
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,18 +2,24 @@ package config
 
 // Config is the internal representation of the complete test splitter client configuration.
 type Config struct {
+	// AccessToken is the access token for the API.
+	AccessToken string
+	// Identifier is the identifier of the build.
+	Identifier string
+	// Mode is the mode of the test splitter.
+	Mode string
+	// Node index is index of the current node.
+	NodeIndex int
+	// OrganizationSlug is the slug of the organization.
+	OrganizationSlug string
 	// Parallelism is the number of parallel tasks to run.
 	Parallelism int
 	// ServerBaseUrl is the base URL of the test splitter server.
 	ServerBaseUrl string
+	// SuiteSlug is the slug of the suite.
+	SuiteSlug string
 	// SuiteToken is the token of the test suite.
 	SuiteToken string
-	// Mode is the mode of the test splitter.
-	Mode string
-	// Identifier is the identifier of the build.
-	Identifier string
-	// Node index is index of the current node.
-	NodeIndex int
 	// TestCommand is the command to run the tests.
 	TestCommand string
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -15,8 +15,10 @@ func setEnv(t *testing.T) {
 	os.Setenv("BUILDKITE_SPLITTER_BASE_URL", "https://build.kite")
 	os.Setenv("BUILDKITE_SPLITTER_MODE", "static")
 	os.Setenv("BUILDKITE_SPLITTER_IDENTIFIER", "xyz")
-	os.Setenv("BUILDKITE_SPLITTER_SUITE_TOKEN", "my_token")
 	os.Setenv("BUILDKITE_TEST_SPLITTER_CMD", "bin/rspec {{testExamples}}")
+	os.Setenv("BUILDKITE_API_ACCESS_TOKEN", "my_token")
+	os.Setenv("BUILDKITE_ORGANIZATION_SLUG", "my_org")
+	os.Setenv("BUILDKITE_SPLITTER_SUITE_SLUG", "my_suite")
 }
 
 func TestNewConfig(t *testing.T) {
@@ -29,13 +31,15 @@ func TestNewConfig(t *testing.T) {
 	}
 
 	want := Config{
-		Parallelism:   60,
-		NodeIndex:     7,
-		ServerBaseUrl: "https://build.kite",
-		Mode:          "static",
-		Identifier:    "xyz",
-		SuiteToken:    "my_token",
-		TestCommand:   "bin/rspec {{testExamples}}",
+		Parallelism:      60,
+		NodeIndex:        7,
+		ServerBaseUrl:    "https://build.kite",
+		Mode:             "static",
+		Identifier:       "xyz",
+		TestCommand:      "bin/rspec {{testExamples}}",
+		AccessToken:      "my_token",
+		OrganizationSlug: "my_org",
+		SuiteSlug:        "my_suite",
 	}
 
 	if diff := cmp.Diff(c, want); diff != "" {
@@ -66,13 +70,15 @@ func TestNewConfig_MissingConfigWithDefault(t *testing.T) {
 	}
 
 	want := Config{
-		Parallelism:   60,
-		NodeIndex:     7,
-		ServerBaseUrl: "https://buildkite.com",
-		Mode:          "static",
-		Identifier:    "xyz",
-		SuiteToken:    "my_token",
-		TestCommand:   "bundle exec rspec {{testExamples}}",
+		Parallelism:      60,
+		NodeIndex:        7,
+		ServerBaseUrl:    "https://api.buildkite.com",
+		Mode:             "static",
+		Identifier:       "xyz",
+		TestCommand:      "bundle exec rspec {{testExamples}}",
+		AccessToken:      "my_token",
+		OrganizationSlug: "my_org",
+		SuiteSlug:        "my_suite",
 	}
 
 	if diff := cmp.Diff(c, want); diff != "" {
@@ -83,7 +89,7 @@ func TestNewConfig_MissingConfigWithDefault(t *testing.T) {
 func TestNewConfig_InvalidConfig(t *testing.T) {
 	setEnv(t)
 	os.Setenv("BUILDKITE_SPLITTER_MODE", "dynamic")
-	os.Unsetenv("BUILDKITE_SPLITTER_SUITE_TOKEN")
+	os.Unsetenv("BUILDKITE_API_ACCESS_TOKEN")
 	defer os.Clearenv()
 
 	_, err := New()

--- a/internal/config/read.go
+++ b/internal/config/read.go
@@ -12,11 +12,14 @@ import (
 // set default values for ServerBaseUrl and Mode if they are not set.
 //
 // Currently, it reads the following environment variables:
-// - BUILDKITE_SPLITTER_IDENTIFIER (Identifier)
+// - BUILDKITE_API_ACCESS_TOKEN (AccessToken)
+// - BUILDKITE_ORGANIZATION_SLUG (OrganizationSlug)
 // - BUILDKITE_PARALLEL_JOB_COUNT (Parallelism)
 // - BUILDKITE_PARALLEL_JOB (NodeIndex)
+// - BUILDKITE_SPLITTER_IDENTIFIER (Identifier)
 // - BUILDKITE_SPLITTER_BASE_URL (ServerBaseUrl)
 // - BUILDKITE_SPLITTER_MODE (Mode)
+// - BUILDKITE_SPLITTER_SUITE_SLUG (SuiteSlug)
 // - BUILDKITE_SPLITTER_SUITE_TOKEN (SuiteToken)
 // - BUILDKITE_TEST_SPLITTER_CMD (TestCommand)
 //
@@ -25,9 +28,13 @@ import (
 func (c *Config) readFromEnv() error {
 	var errs InvalidConfigError
 
+	c.AccessToken = os.Getenv("BUILDKITE_API_ACCESS_TOKEN")
+	c.OrganizationSlug = os.Getenv("BUILDKITE_ORGANIZATION_SLUG")
+	c.SuiteSlug = os.Getenv("BUILDKITE_SPLITTER_SUITE_SLUG")
+
 	c.SuiteToken = getEnvWithDefault("BUILDKITE_SPLITTER_SUITE_TOKEN", os.Getenv("BUILDKITE_ANALYTICS_TOKEN"))
 	c.Identifier = getEnvWithDefault("BUILDKITE_SPLITTER_IDENTIFIER", fmt.Sprintf("%s/%s", os.Getenv("BUILDKITE_BUILD_ID"), os.Getenv("BUILDKITE_STEP_ID")))
-	c.ServerBaseUrl = getEnvWithDefault("BUILDKITE_SPLITTER_BASE_URL", "https://buildkite.com")
+	c.ServerBaseUrl = getEnvWithDefault("BUILDKITE_SPLITTER_BASE_URL", "https://api.buildkite.com")
 	c.Mode = getEnvWithDefault("BUILDKITE_SPLITTER_MODE", "static")
 	c.TestCommand = getEnvWithDefault("BUILDKITE_TEST_SPLITTER_CMD", "bundle exec rspec {{testExamples}}")
 

--- a/internal/config/read.go
+++ b/internal/config/read.go
@@ -20,7 +20,6 @@ import (
 // - BUILDKITE_SPLITTER_BASE_URL (ServerBaseUrl)
 // - BUILDKITE_SPLITTER_MODE (Mode)
 // - BUILDKITE_SPLITTER_SUITE_SLUG (SuiteSlug)
-// - BUILDKITE_SPLITTER_SUITE_TOKEN (SuiteToken)
 // - BUILDKITE_TEST_SPLITTER_CMD (TestCommand)
 //
 // If we are going to support other CI environment in the future,
@@ -32,7 +31,6 @@ func (c *Config) readFromEnv() error {
 	c.OrganizationSlug = os.Getenv("BUILDKITE_ORGANIZATION_SLUG")
 	c.SuiteSlug = os.Getenv("BUILDKITE_SPLITTER_SUITE_SLUG")
 
-	c.SuiteToken = getEnvWithDefault("BUILDKITE_SPLITTER_SUITE_TOKEN", os.Getenv("BUILDKITE_ANALYTICS_TOKEN"))
 	c.Identifier = getEnvWithDefault("BUILDKITE_SPLITTER_IDENTIFIER", fmt.Sprintf("%s/%s", os.Getenv("BUILDKITE_BUILD_ID"), os.Getenv("BUILDKITE_STEP_ID")))
 	c.ServerBaseUrl = getEnvWithDefault("BUILDKITE_SPLITTER_BASE_URL", "https://api.buildkite.com")
 	c.Mode = getEnvWithDefault("BUILDKITE_SPLITTER_MODE", "static")

--- a/internal/config/read_test.go
+++ b/internal/config/read_test.go
@@ -14,21 +14,25 @@ func TestConfigReadFromEnv(t *testing.T) {
 	os.Setenv("BUILDKITE_SPLITTER_BASE_URL", "https://buildkite.localhost")
 	os.Setenv("BUILDKITE_SPLITTER_MODE", "static")
 	os.Setenv("BUILDKITE_SPLITTER_IDENTIFIER", "123")
-	os.Setenv("BUILDKITE_SPLITTER_SUITE_TOKEN", "my_token")
 	os.Setenv("BUILDKITE_TEST_SPLITTER_CMD", "bin/rspec {{testExamples}}")
+	os.Setenv("BUILDKITE_API_ACCESS_TOKEN", "my_token")
+	os.Setenv("BUILDKITE_ORGANIZATION_SLUG", "my_org")
+	os.Setenv("BUILDKITE_SPLITTER_SUITE_SLUG", "my_suite")
 	defer os.Clearenv()
 
 	c := Config{}
 	err := c.readFromEnv()
 
 	want := Config{
-		Parallelism:   10,
-		NodeIndex:     0,
-		ServerBaseUrl: "https://buildkite.localhost",
-		Mode:          "static",
-		Identifier:    "123",
-		SuiteToken:    "my_token",
-		TestCommand:   "bin/rspec {{testExamples}}",
+		Parallelism:      10,
+		NodeIndex:        0,
+		ServerBaseUrl:    "https://buildkite.localhost",
+		Mode:             "static",
+		Identifier:       "123",
+		TestCommand:      "bin/rspec {{testExamples}}",
+		AccessToken:      "my_token",
+		OrganizationSlug: "my_org",
+		SuiteSlug:        "my_suite",
 	}
 
 	if err != nil {
@@ -51,8 +55,8 @@ func TestConfigReadFromEnv_MissingConfigWithDefault(t *testing.T) {
 
 	c := Config{}
 	c.readFromEnv()
-	if c.ServerBaseUrl != "https://buildkite.com" {
-		t.Errorf("ServerBaseUrl = %v, want %v", c.ServerBaseUrl, "https://buildkite.com")
+	if c.ServerBaseUrl != "https://api.buildkite.com" {
+		t.Errorf("ServerBaseUrl = %v, want %v", c.ServerBaseUrl, "https://api.buildkite.com")
 	}
 
 	if c.Mode != "static" {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -50,6 +50,18 @@ func (c *Config) validate() error {
 		}
 	}
 
+	if c.AccessToken == "" {
+		errs.appendFieldError("AccessToken", "must not be blank")
+	}
+
+	if c.OrganizationSlug == "" {
+		errs.appendFieldError("Organization", "must not be blank")
+	}
+
+	if c.SuiteSlug == "" {
+		errs.appendFieldError("Suite", "must not be blank")
+	}
+
 	if len(errs) > 0 {
 		return errs
 	}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -8,14 +8,6 @@ import (
 func (c *Config) validate() error {
 	var errs InvalidConfigError
 
-	if c.SuiteToken == "" {
-		errs.appendFieldError("SuiteToken", "must not be blank")
-	}
-
-	if got, limit := len(c.SuiteToken), 1024; got > limit {
-		errs.appendFieldError("SuiteToken", "was %d bytes long, must not be longer than %d", got, limit)
-	}
-
 	if c.Identifier == "" {
 		errs.appendFieldError("Identifier", "must not be blank")
 	}
@@ -55,11 +47,11 @@ func (c *Config) validate() error {
 	}
 
 	if c.OrganizationSlug == "" {
-		errs.appendFieldError("Organization", "must not be blank")
+		errs.appendFieldError("OrganizationSlug", "must not be blank")
 	}
 
 	if c.SuiteSlug == "" {
-		errs.appendFieldError("Suite", "must not be blank")
+		errs.appendFieldError("SuiteSlug", "must not be blank")
 	}
 
 	if len(errs) > 0 {

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -8,12 +8,14 @@ import (
 
 func createConfig() Config {
 	return Config{
-		ServerBaseUrl: "http://example.com",
-		Mode:          "static",
-		Parallelism:   10,
-		NodeIndex:     0,
-		SuiteToken:    "my_suite_token",
-		Identifier:    "my_identifier",
+		ServerBaseUrl:    "http://example.com",
+		Mode:             "static",
+		Parallelism:      10,
+		NodeIndex:        0,
+		Identifier:       "my_identifier",
+		OrganizationSlug: "my_org",
+		SuiteSlug:        "my_suite",
+		AccessToken:      "my_token",
 	}
 }
 
@@ -50,16 +52,6 @@ func TestConfigValidate_Invalid(t *testing.T) {
 			value: "dynamic",
 		},
 		{
-			name:  "SuiteToken is missing",
-			field: "SuiteToken",
-			value: "",
-		},
-		{
-			name:  "SuiteToken is greater than 1024",
-			field: "SuiteToken",
-			value: strings.Repeat("a", 1025),
-		},
-		{
 			name:  "Identifier is missing",
 			field: "Identifier",
 			value: "",
@@ -84,6 +76,21 @@ func TestConfigValidate_Invalid(t *testing.T) {
 			field: "Parallelism",
 			value: 1341,
 		},
+		{
+			name:  "OrganizationSlug is missing",
+			field: "OrganizationSlug",
+			value: "",
+		},
+		{
+			name:  "SuiteSlug is missing",
+			field: "SuiteSlug",
+			value: "",
+		},
+		{
+			name:  "AccessToken is missing",
+			field: "AccessToken",
+			value: "",
+		},
 	}
 
 	for _, s := range scenario {
@@ -94,14 +101,18 @@ func TestConfigValidate_Invalid(t *testing.T) {
 				c.ServerBaseUrl = s.value.(string)
 			case "Mode":
 				c.Mode = s.value.(string)
-			case "SuiteToken":
-				c.SuiteToken = s.value.(string)
 			case "Identifier":
 				c.Identifier = s.value.(string)
 			case "NodeIndex":
 				c.NodeIndex = s.value.(int)
 			case "Parallelism":
 				c.Parallelism = s.value.(int)
+			case "OrganizationSlug":
+				c.OrganizationSlug = s.value.(string)
+			case "SuiteSlug":
+				c.SuiteSlug = s.value.(string)
+			case "AccessToken":
+				c.AccessToken = s.value.(string)
 			}
 
 			err := c.validate()

--- a/main.go
+++ b/main.go
@@ -153,8 +153,7 @@ func fetchOrCreateTestPlan(ctx context.Context, cfg config.Config, files []strin
 		Format: "files",
 	}
 
-	testPlan, err := apiClient.CreateTestPlan(ctx, api.TestPlanParams{
-		SuiteToken:  cfg.SuiteToken,
+	testPlan, err := apiClient.CreateTestPlan(ctx, cfg.SuiteSlug, api.TestPlanParams{
 		Mode:        cfg.Mode,
 		Identifier:  cfg.Identifier,
 		Parallelism: cfg.Parallelism,

--- a/main.go
+++ b/main.go
@@ -129,14 +129,15 @@ func fetchOrCreateTestPlan(ctx context.Context, cfg config.Config, files []strin
 		OrganizationSlug: cfg.OrganizationSlug,
 	})
 
-	// Fetch the plan from the server's cache first.
+	// Fetch the plan from the server's cache.
 	cachedPlan, err := apiClient.FetchTestPlan(cfg.SuiteSlug, cfg.Identifier)
-	if cachedPlan != nil {
-		return *cachedPlan, nil
-	}
 
 	if err != nil {
 		return plan.TestPlan{}, err
+	}
+
+	if cachedPlan != nil {
+		return *cachedPlan, nil
 	}
 
 	// If the cache is empty, create a new plan.

--- a/main_test.go
+++ b/main_test.go
@@ -41,7 +41,6 @@ func TestFetchOrCreateTestPlan(t *testing.T) {
 	cfg := config.Config{
 		NodeIndex:     0,
 		Parallelism:   10,
-		SuiteToken:    "suite_token",
 		Identifier:    "identifier",
 		ServerBaseUrl: svr.URL,
 	}
@@ -80,6 +79,10 @@ func TestFetchOrCreateTestPlan_PlanError(t *testing.T) {
 	"tasks": {}
 }`
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// simulate cache miss for GET test_plan so it will trigger the test plan creation
+		if r.Method == http.MethodGet {
+			w.WriteHeader(http.StatusNotFound)
+		}
 		fmt.Fprint(w, response)
 	}))
 	defer svr.Close()
@@ -88,7 +91,6 @@ func TestFetchOrCreateTestPlan_PlanError(t *testing.T) {
 	cfg := config.Config{
 		NodeIndex:     0,
 		Parallelism:   2,
-		SuiteToken:    "suite_token",
 		Identifier:    "identifier",
 		ServerBaseUrl: svr.URL,
 	}
@@ -126,7 +128,6 @@ func TestFetchOrCreateTestPlan_InternalServerError(t *testing.T) {
 	cfg := config.Config{
 		NodeIndex:     0,
 		Parallelism:   3,
-		SuiteToken:    "suite_token",
 		Identifier:    "identifier",
 		ServerBaseUrl: svr.URL,
 	}
@@ -161,7 +162,6 @@ func TestFetchOrCreateTestPlan_BadRequest(t *testing.T) {
 	cfg := config.Config{
 		NodeIndex:     0,
 		Parallelism:   2,
-		SuiteToken:    "suite_token",
 		Identifier:    "identifier",
 		ServerBaseUrl: svr.URL,
 	}


### PR DESCRIPTION
### ⚠️ BREAKING CHANGES
These changes introduced 3 required configs
- `BUILDKITE_API_ACCESS_TOKEN`. You now need Buildkite API access token that has `read_suites`, `read_test_plan`, and `write_test_plan` scopes.
- `BUILDKITE_ORGANIZATION_SLUG`. This is available in your Buildkite Pipeline environment, so you don't need to set it manually.
- `BUILDKITE_SPLITTER_SUITE_SLUG`. This replaces `BUILDKITE_SPLITTER_SUITE_TOKEN` and need to be set manually.


### Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->
As part of split by example implementation, we want to change how the client fetch and create test plan from the server. The new flow will look like this
```
// main.go
func fetchOrCreatePlan() {
  plan := api.FetchPlan()

  if plan != nil {
    return plan
  }

  params := buildParamsToCreatePlan()

  plan := api.CreatePlan(params)

  if plan != nil {
    return plan
  }
}
```

This PR also replaced the endpoint to the new endpoint.

### Changes

<!--
List of what the PR changes.

Can skip if changes are simple or clear from the commit messages.
-->
- Add 3 new configs
- Add `httpClient` to `api.client` struct that has Transport to attach access token to each request
- Implement `FetchTestPlan` in the `api.client` struct
- Replace endpoint in `CreateTestPlan` to the new endpoint
- Removed `BUILDKITE_SPLITTER_SUITE_TOKEN` from config

### Testing

<!--
Call out any additional testing (beyond the automated tests) you felt was necessary and the results, e.g. running it manually, or running as part of another pipeline.
-->
As this is a breaking change, I suggest testing it manually against a local Buildkite server (or Prod). I tested it manually against my local Buildkite server.
