### PR TITLE
Retry failed tests with a max retry count

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The available Go binaries
 | `BUILDKITE_SPLITTER_TEST_FILE_PATTERN` | `spec/**/*_spec.rb` | Optional, glob pattern for discovering test files that need to be executed. </br> *It accepts pattern syntax supported by [zzglob](https://github.com/DrJosh9000/zzglob?tab=readme-ov-file#pattern-syntax) library*. |
 | `BUILDKITE_SPLITTER_TEST_FILE_EXCLUDE_PATTERN` | - | Optional, glob pattern to use for excluding test files or directory. </br> *It accepts pattern syntax supported by [zzglob](https://github.com/DrJosh9000/zzglob?tab=readme-ov-file#pattern-syntax) library.* |
 | `BUILDKITE_SPLITTER_SUITE_SLUG` | - | Required, the slug of your test suite. |
+| `BUILDKITE_SPLITTER_RETRY_COUNT` | 0 | Optional. Test splitter runs the test command defined in `BUILDKITE_SPLITTER_TEST_CMD`, and retries the failing tests maximum `BUILDKITE_SPLITTER_RETRY_COUNT` times. For Rspec, the test splitter runs `BUILDKITE_SPLITTER_TEST_CMD` with `--only-failures` as the retry command. |
 
 For most use cases, Test Splitter should work out of the box due to the default values available from your Buildkite environment.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,8 @@ type Config struct {
 	SuiteSlug string
 	// TestCommand is the command to run the tests.
 	TestCommand string
+	// MaxRetries is the maximum number of retries for a failed test.
+	MaxRetries int
 }
 
 // New wraps the readFromEnv and validate functions to create a new Config struct.

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"strconv"
 )
 
 // getEnvWithDefault retrieves the value of the environment variable named by the key.
@@ -16,4 +17,19 @@ func getEnvWithDefault(key string, defaultValue string) string {
 		return defaultValue
 	}
 	return value
+}
+
+func getIntEnvWithDefault(key string, defaultValue int) (int, error) {
+	value := os.Getenv(key)
+	// If the environment variable is not set, return the default value.
+	if value == "" {
+		return defaultValue, nil
+	}
+	// Convert the value to int, and return error if it fails.
+	valueInt, err := strconv.Atoi(value)
+	if err != nil {
+		return defaultValue, err
+	}
+	// Return the value if it's successfully converted to int.
+	return valueInt, nil
 }

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -1,9 +1,66 @@
 package config
 
 import (
+	"errors"
 	"os"
+	"strconv"
 	"testing"
 )
+
+func TestGetIntEnvWithDefault(t *testing.T) {
+	os.Setenv("MY_KEY", "10")
+	defer os.Unsetenv("MY_KEY")
+
+	os.Setenv("EMPTY_KEY", "")
+	defer os.Unsetenv("EMPTY_KEY")
+
+	os.Setenv("INVALID_KEY", "invalid_value")
+	defer os.Unsetenv("INVALID_KEY")
+
+	tests := []struct {
+		key          string
+		defaultValue int
+		want         int
+		err          error
+	}{
+		{
+			key:          "MY_KEY",
+			defaultValue: 20,
+			want:         10,
+			err:          nil,
+		},
+		{
+			key:          "NON_EXISTENT_KEY",
+			defaultValue: 30,
+			want:         30,
+			err:          nil,
+		},
+		{
+			key:          "EMPTY_KEY",
+			defaultValue: 40,
+			want:         40,
+			err:          nil,
+		},
+		{
+			key:          "INVALID_KEY",
+			defaultValue: 50,
+			want:         50,
+			err:          strconv.ErrSyntax,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			got, err := getIntEnvWithDefault(tt.key, tt.defaultValue)
+			if err != nil && !errors.Is(err, tt.err) {
+				t.Errorf("getIntEnvWithDefault(%q, %d) error = %v, want %v", tt.key, tt.defaultValue, err, tt.err)
+			}
+			if got != tt.want {
+				t.Errorf("getIntEnvWithDefault(%q, %d) = %d, want %d", tt.key, tt.defaultValue, got, tt.want)
+			}
+		})
+	}
+}
 
 func TestGetEnvWithDefault(t *testing.T) {
 	os.Setenv("MY_KEY", "my_value")

--- a/internal/config/read.go
+++ b/internal/config/read.go
@@ -21,7 +21,7 @@ import (
 // - BUILDKITE_SPLITTER_MODE (Mode)
 // - BUILDKITE_SPLITTER_SUITE_SLUG (SuiteSlug)
 // - BUILDKITE_SPLITTER_TEST_CMD (TestCommand)
-// - BUILDKITE_SPLITTER_TEST_FAILURE_RETRY_COUNT (MaxRetries)
+// - BUILDKITE_SPLITTER_RETRY_COUNT (MaxRetries)
 //
 // If we are going to support other CI environment in the future,
 // we will need to change where we read the configuration from.
@@ -37,10 +37,10 @@ func (c *Config) readFromEnv() error {
 	c.Mode = getEnvWithDefault("BUILDKITE_SPLITTER_MODE", "static")
 	c.TestCommand = os.Getenv("BUILDKITE_SPLITTER_TEST_CMD")
 
-	MaxRetries, err := getIntEnvWithDefault("BUILDKITE_SPLITTER_TEST_FAILURE_RETRY_COUNT", 0)
+	MaxRetries, err := getIntEnvWithDefault("BUILDKITE_SPLITTER_RETRY_COUNT", 0)
 	c.MaxRetries = MaxRetries
 	if err != nil {
-		errs.appendFieldError("MaxRetries", "was %q, must be a number", os.Getenv("BUILDKITE_SPLITTER_TEST_FAILURE_RETRY_COUNT"))
+		errs.appendFieldError("MaxRetries", "was %q, must be a number", os.Getenv("BUILDKITE_SPLITTER_RETRY_COUNT"))
 	}
 
 	parallelism := os.Getenv("BUILDKITE_PARALLEL_JOB_COUNT")

--- a/internal/config/read.go
+++ b/internal/config/read.go
@@ -21,6 +21,7 @@ import (
 // - BUILDKITE_SPLITTER_MODE (Mode)
 // - BUILDKITE_SPLITTER_SUITE_SLUG (SuiteSlug)
 // - BUILDKITE_SPLITTER_TEST_CMD (TestCommand)
+// - BUILDKITE_SPLITTER_TEST_FAILURE_RETRY_COUNT (MaxRetries)
 //
 // If we are going to support other CI environment in the future,
 // we will need to change where we read the configuration from.
@@ -35,6 +36,12 @@ func (c *Config) readFromEnv() error {
 	c.ServerBaseUrl = getEnvWithDefault("BUILDKITE_SPLITTER_BASE_URL", "https://api.buildkite.com")
 	c.Mode = getEnvWithDefault("BUILDKITE_SPLITTER_MODE", "static")
 	c.TestCommand = os.Getenv("BUILDKITE_SPLITTER_TEST_CMD")
+
+	MaxRetries, err := getIntEnvWithDefault("BUILDKITE_SPLITTER_TEST_FAILURE_RETRY_COUNT", 0)
+	c.MaxRetries = MaxRetries
+	if err != nil {
+		errs.appendFieldError("MaxRetries", "was %q, must be a number", os.Getenv("BUILDKITE_SPLITTER_TEST_FAILURE_RETRY_COUNT"))
+	}
 
 	parallelism := os.Getenv("BUILDKITE_PARALLEL_JOB_COUNT")
 	parallelismInt, err := strconv.Atoi(parallelism)

--- a/internal/config/read_test.go
+++ b/internal/config/read_test.go
@@ -15,13 +15,10 @@ func TestConfigReadFromEnv(t *testing.T) {
 	os.Setenv("BUILDKITE_SPLITTER_MODE", "static")
 	os.Setenv("BUILDKITE_SPLITTER_IDENTIFIER", "123")
 	os.Setenv("BUILDKITE_SPLITTER_TEST_CMD", "bin/rspec {{testExamples}}")
-<<<<<<< HEAD
 	os.Setenv("BUILDKITE_API_ACCESS_TOKEN", "my_token")
 	os.Setenv("BUILDKITE_ORGANIZATION_SLUG", "my_org")
 	os.Setenv("BUILDKITE_SPLITTER_SUITE_SLUG", "my_suite")
-=======
 	os.Setenv("BUILDKITE_SPLITTER_RETRY_COUNT", "3")
->>>>>>> 9af6613 (add test cases and code comments)
 	defer os.Clearenv()
 
 	c := Config{}
@@ -37,7 +34,7 @@ func TestConfigReadFromEnv(t *testing.T) {
 		AccessToken:      "my_token",
 		OrganizationSlug: "my_org",
 		SuiteSlug:        "my_suite",
-		MaxRetries:     	3,
+		MaxRetries:       3,
 	}
 
 	if err != nil {

--- a/internal/config/read_test.go
+++ b/internal/config/read_test.go
@@ -15,9 +15,13 @@ func TestConfigReadFromEnv(t *testing.T) {
 	os.Setenv("BUILDKITE_SPLITTER_MODE", "static")
 	os.Setenv("BUILDKITE_SPLITTER_IDENTIFIER", "123")
 	os.Setenv("BUILDKITE_SPLITTER_TEST_CMD", "bin/rspec {{testExamples}}")
+<<<<<<< HEAD
 	os.Setenv("BUILDKITE_API_ACCESS_TOKEN", "my_token")
 	os.Setenv("BUILDKITE_ORGANIZATION_SLUG", "my_org")
 	os.Setenv("BUILDKITE_SPLITTER_SUITE_SLUG", "my_suite")
+=======
+	os.Setenv("BUILDKITE_SPLITTER_RETRY_COUNT", "3")
+>>>>>>> 9af6613 (add test cases and code comments)
 	defer os.Clearenv()
 
 	c := Config{}
@@ -33,6 +37,7 @@ func TestConfigReadFromEnv(t *testing.T) {
 		AccessToken:      "my_token",
 		OrganizationSlug: "my_org",
 		SuiteSlug:        "my_suite",
+		MaxRetries:     	3,
 	}
 
 	if err != nil {
@@ -49,6 +54,7 @@ func TestConfigReadFromEnv_MissingConfigWithDefault(t *testing.T) {
 	os.Setenv("BUILDKITE_SPLITTER_MODE", "")
 	os.Setenv("BUILDKITE_SPLITTER_TEST_CMD", "")
 	os.Setenv("BUILDKITE_SPLITTER_IDENTIFIER", "")
+	os.Setenv("BUILDKITE_SPLITTER_RETRY_COUNT", "")
 	os.Setenv("BUILDKITE_BUILD_ID", "123")
 	os.Setenv("BUILDKITE_STEP_ID", "456")
 	defer os.Clearenv()
@@ -65,6 +71,10 @@ func TestConfigReadFromEnv_MissingConfigWithDefault(t *testing.T) {
 
 	if c.Identifier != "123/456" {
 		t.Errorf("Identifier = %v, want %v", c.Identifier, "123/456")
+	}
+
+	if c.MaxRetries != 0 {
+		t.Errorf("MaxRetries = %v, want %v", c.MaxRetries, 0)
 	}
 }
 

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -8,6 +8,10 @@ import (
 func (c *Config) validate() error {
 	var errs InvalidConfigError
 
+	if c.MaxRetries < 0 {
+		errs.appendFieldError("MaxRetries", "was %d, must be greater than or equal to 0", c.MaxRetries)
+	}
+
 	if c.Identifier == "" {
 		errs.appendFieldError("Identifier", "must not be blank")
 	}

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -16,6 +16,7 @@ func createConfig() Config {
 		OrganizationSlug: "my_org",
 		SuiteSlug:        "my_suite",
 		AccessToken:      "my_token",
+		MaxRetries:       3,
 	}
 }
 
@@ -147,6 +148,22 @@ func TestConfigValidate_Invalid(t *testing.T) {
 		// So, we expect 2 validation errors.
 		if len(invConfigError) != 2 {
 			t.Errorf("config.validate() error length = %d, want 2", len(invConfigError))
+		}
+	})
+
+	t.Run("MaxRetries is less than 0", func(t *testing.T) {
+		c := createConfig()
+		c.MaxRetries = -1
+		err := c.validate()
+
+		var invConfigError InvalidConfigError
+		if !errors.As(err, &invConfigError) {
+			t.Errorf("config.validate() error = %v, want InvalidConfigError", err)
+			return
+		}
+
+		if len(invConfigError) != 1 {
+			t.Errorf("config.validate() error length = %d, want 1", len(invConfigError))
 		}
 	})
 }

--- a/internal/runner/rspec.go
+++ b/internal/runner/rspec.go
@@ -58,6 +58,7 @@ func (r Rspec) RetryCommand(defaultTestCommand string) (*exec.Cmd, error) {
 		return n == "{{testExamples}}"
 	})
 	words = slices.Insert(words, len(words), "--only-failures")
+	fmt.Println(shellquote.Join(words...))
 
 	cmd := exec.Command(words[0], words[1:]...)
 	cmd.Stderr = os.Stderr

--- a/internal/runner/rspec.go
+++ b/internal/runner/rspec.go
@@ -45,6 +45,26 @@ func (r Rspec) GetFiles() ([]string, error) {
 	return files, nil
 }
 
+func (r Rspec) RetryCommand(defaultTestCommand string) (*exec.Cmd, error) {
+	// use default test command to build retry command
+	// remove all occurrences of "{{testExamples}}" and append "--only-failures"
+
+	// TODO: support custom retry command in the future
+	words, err := shellquote.Split(defaultTestCommand)
+	if err != nil {
+		return nil, err
+	}
+	words = slices.DeleteFunc(words, func(n string) bool {
+		return n == "{{testExamples}}"
+	})
+	words = slices.Insert(words, len(words), "--only-failures")
+
+	cmd := exec.Command(words[0], words[1:]...)
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+	return cmd, nil
+}
+
 // Command returns an exec.Cmd that will run the rspec command
 func (r Rspec) Command(testCases []string) (*exec.Cmd, error) {
 	commandName, commandArgs, err := r.commandNameAndArgs(testCases)

--- a/internal/runner/rspec.go
+++ b/internal/runner/rspec.go
@@ -45,12 +45,12 @@ func (r Rspec) GetFiles() ([]string, error) {
 	return files, nil
 }
 
-func (r Rspec) RetryCommand(defaultTestCommand string) (*exec.Cmd, error) {
+func (r Rspec) RetryCommand() (*exec.Cmd, error) {
 	// use default test command to build retry command
 	// remove all occurrences of "{{testExamples}}" and append "--only-failures"
 
 	// TODO: support custom retry command in the future
-	words, err := shellquote.Split(defaultTestCommand)
+	words, err := shellquote.Split(r.TestCommand)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/runner/rspec_test.go
+++ b/internal/runner/rspec_test.go
@@ -90,6 +90,21 @@ func TestCommandNameAndArgs_InvalidTestCommand(t *testing.T) {
 	}
 }
 
+func TestRetryCommand_DefaultRetryCommand(t *testing.T) {
+	testCommand := "bin/rspec --options {{testExamples}}"
+	rspec := NewRspec(testCommand)
+
+	got, err := rspec.RetryCommand()
+	if err != nil {
+		t.Errorf("Rspec.RetryCommand() error = %v", err)
+	}
+
+	want := "bin/rspec --options --only-failures"
+	if diff := cmp.Diff(got.String(), want); diff != "" {
+		t.Errorf("Rspec.RetryCommand() diff (-got +want):\n%s", diff)
+	}
+}
+
 func TestRspecDiscoveryPattern_Default(t *testing.T) {
 	rspec := Rspec{}
 	got := rspec.discoveryPattern()

--- a/main.go
+++ b/main.go
@@ -116,6 +116,7 @@ func main() {
 		if exitError := new(exec.ExitError); errors.As(err, &exitError) {
 			exitCode := exitError.ExitCode()
 			if cfg.MaxRetries == 0 {
+				// If retry is disabled, we exit immediately with the same exit code from the test runner
 				logErrorAndExit(exitCode, "Rspec exited with error %d", err)
 			} else {
 				retryFailedTests(testRunner, cfg.MaxRetries)
@@ -147,10 +148,12 @@ func retryFailedTests(testRunner runner.Rspec, maxRetries int) {
 			if exitError := new(exec.ExitError); errors.As(err, &exitError) {
 				exitCode := exitError.ExitCode()
 				if retries >= maxRetries {
+					// If the command exits with an error and we've reached the maximum number of retries, we exit.
 					logErrorAndExit(exitCode, "Rspec exited with error %d", err)
 				}
 			}
 		} else {
+			// If the command exits successfully, we break the loop.
 			break
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -119,7 +119,12 @@ func main() {
 				// If retry is disabled, we exit immediately with the same exit code from the test runner
 				logErrorAndExit(exitCode, "Rspec exited with error %v", err)
 			} else {
-				retryFailedTests(testRunner, cfg.MaxRetries)
+				retryExitCode := retryFailedTests(testRunner, cfg.MaxRetries)
+				if retryExitCode == 0 {
+					os.Exit(0)
+				} else {
+					logErrorAndExit(retryExitCode, "Rspec exited with error %v after retry failing tests", err)
+				}
 			}
 		}
 		logErrorAndExit(16, "Couldn't run tests: %v", err)
@@ -129,7 +134,7 @@ func main() {
 	close(finishCh)
 }
 
-func retryFailedTests(testRunner runner.Rspec, maxRetries int) {
+func retryFailedTests(testRunner runner.Rspec, maxRetries int) int {
 	// Retry failed tests
 	retries := 0
 	for retries < maxRetries {
@@ -151,14 +156,15 @@ func retryFailedTests(testRunner runner.Rspec, maxRetries int) {
 				exitCode := exitError.ExitCode()
 				if retries >= maxRetries {
 					// If the command exits with an error and we've reached the maximum number of retries, we exit.
-					logErrorAndExit(exitCode, "Rspec exited with error %v after retry failing tests", err)
+					return exitCode
 				}
 			}
 		} else {
 			// If the failing tests pass after retry (test command exits without error), we exit with code 0.
-			os.Exit(0)
+			return 0
 		}
 	}
+	return 1
 }
 
 // logErrorAndExit logs an error message and exits with the given exit code.

--- a/main.go
+++ b/main.go
@@ -117,7 +117,7 @@ func main() {
 			exitCode := exitError.ExitCode()
 			if cfg.MaxRetries == 0 {
 				// If retry is disabled, we exit immediately with the same exit code from the test runner
-				logErrorAndExit(exitCode, "Rspec exited with error %d", err)
+				logErrorAndExit(exitCode, "Rspec exited with error %v", err)
 			} else {
 				retryFailedTests(testRunner, cfg.MaxRetries)
 			}
@@ -134,6 +134,8 @@ func retryFailedTests(testRunner runner.Rspec, maxRetries int) {
 	retries := 0
 	for retries < maxRetries {
 		retries++
+		fmt.Printf("Attempt %d of %d to retry failing tests\n", retries, maxRetries)
+
 		cmd, err := testRunner.RetryCommand()
 		if err != nil {
 			logErrorAndExit(16, "Couldn't process retry command: %v", err)
@@ -149,7 +151,7 @@ func retryFailedTests(testRunner runner.Rspec, maxRetries int) {
 				exitCode := exitError.ExitCode()
 				if retries >= maxRetries {
 					// If the command exits with an error and we've reached the maximum number of retries, we exit.
-					logErrorAndExit(exitCode, "Rspec exited with error %d", err)
+					logErrorAndExit(exitCode, "Rspec exited with error %v after retry failing tests", err)
 				}
 			}
 		} else {

--- a/main.go
+++ b/main.go
@@ -155,8 +155,8 @@ func retryFailedTests(testRunner runner.Rspec, maxRetries int) {
 				}
 			}
 		} else {
-			// If the command exits successfully, we break the loop.
-			break
+			// If the failing tests pass after retry (test command exits without error), we exit with code 0.
+			os.Exit(0)
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -118,7 +118,7 @@ func main() {
 			if cfg.MaxRetries == 0 {
 				logErrorAndExit(exitCode, "Rspec exited with error %d", err)
 			} else {
-				retryFailedTests(testRunner, cfg)
+				retryFailedTests(testRunner, cfg.MaxRetries)
 			}
 		}
 		logErrorAndExit(16, "Couldn't run tests: %v", err)
@@ -128,12 +128,12 @@ func main() {
 	close(finishCh)
 }
 
-func retryFailedTests(testRunner runner.Rspec, cfg config.Config) {
+func retryFailedTests(testRunner runner.Rspec, maxRetries int) {
 	// Retry failed tests
 	retries := 0
-	for retries < cfg.MaxRetries {
+	for retries < maxRetries {
 		retries++
-		cmd, err := testRunner.RetryCommand(cfg.TestCommand)
+		cmd, err := testRunner.RetryCommand()
 		if err != nil {
 			logErrorAndExit(16, "Couldn't process retry command: %v", err)
 		}
@@ -146,7 +146,7 @@ func retryFailedTests(testRunner runner.Rspec, cfg config.Config) {
 		if err != nil {
 			if exitError := new(exec.ExitError); errors.As(err, &exitError) {
 				exitCode := exitError.ExitCode()
-				if retries >= cfg.MaxRetries {
+				if retries >= maxRetries {
 					logErrorAndExit(exitCode, "Rspec exited with error %d", err)
 				}
 			}

--- a/main_test.go
+++ b/main_test.go
@@ -10,8 +10,29 @@ import (
 
 	"github.com/buildkite/test-splitter/internal/config"
 	"github.com/buildkite/test-splitter/internal/plan"
+	"github.com/buildkite/test-splitter/internal/runner"
 	"github.com/google/go-cmp/cmp"
 )
+
+func TestRetryFailedTests(t *testing.T) {
+	testRunner := runner.NewRspec("true")
+	maxRetries := 3
+	exitCode := retryFailedTests(testRunner, maxRetries)
+	want := 0
+	if exitCode != want {
+		t.Errorf("retryFailedTests(%v, %v) = %v, want %v", testRunner, maxRetries, exitCode, want)
+	}
+}
+
+func TestRetryFailedTests_Failure(t *testing.T) {
+	testRunner := runner.NewRspec("false")
+	maxRetries := 3
+	exitCode := retryFailedTests(testRunner, maxRetries)
+	want := 1
+	if exitCode != want {
+		t.Errorf("retryFailedTests(%v, %v) = %v, want %v", testRunner, maxRetries, exitCode, want)
+	}
+}
 
 func TestFetchOrCreateTestPlan(t *testing.T) {
 	files := []string{"apple"}


### PR DESCRIPTION
### Description
bk/bk pipeline rerun failed rspec tests outside of test splitter. We should support retry failing tests in the test splitter.


### Context

On basecamp, we decided to implement retry failing tests in two steps. This PR is part of step 1

### Changes

- Read from `BUILDKITE_SPLITTER_RETRY_COUNT` for max retry attempts 
- Create retry command from the original test command: Append `--only-failures` to the original test command, and remove all occurrences of `{{testExamples}}`
- Retry failed tests if retry is enabled (`BUILDKITE_SPLITTER_RETRY_COUNT` > 0)

### Testing

<!--
Call out any additional testing (beyond the automated tests) you felt was necessary and the results, e.g. running it manually, or running as part of another pipeline.
-->
Testing the retry feature locally

A screenshot of failing tests passed after retry: 

<img width="437" alt="Screenshot 2024-05-21 at 4 39 54 pm" src="https://github.com/buildkite/test-splitter/assets/47379003/fb715507-bc45-41a0-9ea0-0c61f712f17d">

A screenshot of failing tests still failed after used all retry attempts: 
<img width="497" alt="Screenshot 2024-05-22 at 9 49 26 am" src="https://github.com/buildkite/test-splitter/assets/47379003/d2b66d2c-05be-43ef-8b87-b321abcd8b7d">
