### PR TITLE
Add --version flag to aid in debugging.

### DIFF
--- a/.buildkite/steps/build-binary.sh
+++ b/.buildkite/steps/build-binary.sh
@@ -13,6 +13,7 @@ BUILD_NUMBER="${BUILDKITE_BUILD_NUMBER}"
 NAME="test-splitter"
 BUILD_PATH="pkg"
 BINARY_FILENAME="${NAME}-${GOOS}-${GOARCH}"
+VERSION=$(cat version/VERSION)
 
 if [[ "${GOOS}" = "dragonflybsd" ]]; then
   export GOOS="dragonfly"
@@ -42,7 +43,11 @@ fi
 export CGO_ENABLED=0
 
 mkdir -p "${BUILD_PATH}"
-go build -v -o "${BUILD_PATH}/${BINARY_FILENAME}" .
+go build \
+  -v \
+  -o "${BUILD_PATH}/${BINARY_FILENAME}" \
+  -ldflags="-X 'main.Version=v${VERSION}'" \
+  .
 
 chmod +x "${BUILD_PATH}/${BINARY_FILENAME}"
 

--- a/main.go
+++ b/main.go
@@ -20,14 +20,24 @@ import (
 	"github.com/buildkite/test-splitter/internal/runner"
 )
 
+var Version = ""
+
 func main() {
 	// TODO: detect test runner and use appropriate runner
 	testRunner := runner.Rspec{}
+
+	versionFlag := flag.Bool("version", false, "print version information")
+
 	// Gathering files
 	filesFlag := flag.String("files", "", "string of file names for splitting")
 	flag.Parse()
 
 	var files []string
+
+	if *versionFlag {
+		fmt.Println(Version)
+		os.Exit(0)
+	}
 
 	if *filesFlag != "" {
 		files = strings.Split(*filesFlag, ",")


### PR DESCRIPTION
### Description

Self-explanatory from title.

### Context

https://linear.app/buildkite/issue/TAT-154/add-a-version-flag-to-the-splitter-to-aid-in-debugging

### Changes

NA

### Testing

`test-splitter -v or test-splitter --version`
