### PR TITLE
Refactor test command default handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The available Go binaries
 |  `BUILDKITE_SPLITTER_IDENTIFIER` | `BUILDKITE_BUILD_ID/BUILDKITE_STEP_ID` | Optional. Test Splitter uses the identifier to store and fetch the test plan and must be unique for each build and steps group. By default it will use a composite of `BUILDKITE_BUILD_ID` and `BUILDKITE_STEP_ID`, but it can be overridden by specifying the `BUILDKITE_SPLITTER_IDENTIFIER`. `BUILDKITE_BUILD_ID` and `BUILDKITE_STEP_ID` must be accessible by the client when using the default. |
 | `BUILDKITE_SPLITTER_TEST_FILE_PATTERN` | `spec/**/*_spec.rb` | Optional, glob pattern for discovering test files that need to be executed. </br> *It accepts pattern syntax supported by [zzglob](https://github.com/DrJosh9000/zzglob?tab=readme-ov-file#pattern-syntax) library*. |
 | `BUILDKITE_SPLITTER_TEST_FILE_EXCLUDE_PATTERN` | - | Optional, glob pattern to use for excluding test files or directory. </br> *It accepts pattern syntax supported by [zzglob](https://github.com/DrJosh9000/zzglob?tab=readme-ov-file#pattern-syntax) library.* |
-| `BUILDKITE_TEST_SPLITTER_CMD` | `bundle exec rspec {{testExamples}}` | Optional, test command for running your tests. Test splitter will fill in the `{{testExamples}}` placeholder with the test splitting results |
+| `BUILDKITE_SPLITTER_TEST_CMD` | `bundle exec rspec {{testExamples}}` | Optional, test command for running your tests. Test splitter will fill in the `{{testExamples}}` placeholder with the test splitting results |
 
 For most use cases, Test Splitter should work out of the box due to the default values available from your Buildkite environment.
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -72,7 +72,6 @@ func TestNewConfig_MissingConfigWithDefault(t *testing.T) {
 		Mode:          "static",
 		Identifier:    "xyz",
 		SuiteToken:    "my_token",
-		TestCommand:   "bundle exec rspec {{testExamples}}",
 	}
 
 	if diff := cmp.Diff(c, want); diff != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -16,7 +16,7 @@ func setEnv(t *testing.T) {
 	os.Setenv("BUILDKITE_SPLITTER_MODE", "static")
 	os.Setenv("BUILDKITE_SPLITTER_IDENTIFIER", "xyz")
 	os.Setenv("BUILDKITE_SPLITTER_SUITE_TOKEN", "my_token")
-	os.Setenv("BUILDKITE_TEST_SPLITTER_CMD", "bin/rspec {{testExamples}}")
+	os.Setenv("BUILDKITE_SPLITTER_TEST_CMD", "bin/rspec {{testExamples}}")
 }
 
 func TestNewConfig(t *testing.T) {
@@ -57,7 +57,7 @@ func TestNewConfig_MissingConfigWithDefault(t *testing.T) {
 	setEnv(t)
 	os.Unsetenv("BUILDKITE_SPLITTER_MODE")
 	os.Unsetenv("BUILDKITE_SPLITTER_BASE_URL")
-	os.Unsetenv("BUILDKITE_TEST_SPLITTER_CMD")
+	os.Unsetenv("BUILDKITE_SPLITTER_TEST_CMD")
 	defer os.Clearenv()
 
 	c, err := New()

--- a/internal/config/read.go
+++ b/internal/config/read.go
@@ -18,7 +18,7 @@ import (
 // - BUILDKITE_SPLITTER_BASE_URL (ServerBaseUrl)
 // - BUILDKITE_SPLITTER_MODE (Mode)
 // - BUILDKITE_SPLITTER_SUITE_TOKEN (SuiteToken)
-// - BUILDKITE_TEST_SPLITTER_CMD (TestCommand)
+// - BUILDKITE_SPLITTER_TEST_CMD (TestCommand)
 //
 // If we are going to support other CI environment in the future,
 // we will need to change where we read the configuration from.
@@ -29,7 +29,7 @@ func (c *Config) readFromEnv() error {
 	c.Identifier = getEnvWithDefault("BUILDKITE_SPLITTER_IDENTIFIER", fmt.Sprintf("%s/%s", os.Getenv("BUILDKITE_BUILD_ID"), os.Getenv("BUILDKITE_STEP_ID")))
 	c.ServerBaseUrl = getEnvWithDefault("BUILDKITE_SPLITTER_BASE_URL", "https://buildkite.com")
 	c.Mode = getEnvWithDefault("BUILDKITE_SPLITTER_MODE", "static")
-	c.TestCommand = os.Getenv("BUILDKITE_TEST_SPLITTER_CMD")
+	c.TestCommand = os.Getenv("BUILDKITE_SPLITTER_TEST_CMD")
 
 	parallelism := os.Getenv("BUILDKITE_PARALLEL_JOB_COUNT")
 	parallelismInt, err := strconv.Atoi(parallelism)

--- a/internal/config/read.go
+++ b/internal/config/read.go
@@ -29,7 +29,7 @@ func (c *Config) readFromEnv() error {
 	c.Identifier = getEnvWithDefault("BUILDKITE_SPLITTER_IDENTIFIER", fmt.Sprintf("%s/%s", os.Getenv("BUILDKITE_BUILD_ID"), os.Getenv("BUILDKITE_STEP_ID")))
 	c.ServerBaseUrl = getEnvWithDefault("BUILDKITE_SPLITTER_BASE_URL", "https://buildkite.com")
 	c.Mode = getEnvWithDefault("BUILDKITE_SPLITTER_MODE", "static")
-	c.TestCommand = getEnvWithDefault("BUILDKITE_TEST_SPLITTER_CMD", "bundle exec rspec {{testExamples}}")
+	c.TestCommand = os.Getenv("BUILDKITE_TEST_SPLITTER_CMD")
 
 	parallelism := os.Getenv("BUILDKITE_PARALLEL_JOB_COUNT")
 	parallelismInt, err := strconv.Atoi(parallelism)

--- a/internal/config/read_test.go
+++ b/internal/config/read_test.go
@@ -59,10 +59,6 @@ func TestConfigReadFromEnv_MissingConfigWithDefault(t *testing.T) {
 		t.Errorf("Mode = %v, want %v", c.Mode, "static")
 	}
 
-	if c.TestCommand != "bundle exec rspec {{testExamples}}" {
-		t.Errorf("TestCommand = %v, want %v", c.TestCommand, "bundle exec rspec {{testExamples}}")
-	}
-
 	if c.Identifier != "123/456" {
 		t.Errorf("Identifier = %v, want %v", c.Identifier, "123/456")
 	}

--- a/internal/config/read_test.go
+++ b/internal/config/read_test.go
@@ -15,7 +15,7 @@ func TestConfigReadFromEnv(t *testing.T) {
 	os.Setenv("BUILDKITE_SPLITTER_MODE", "static")
 	os.Setenv("BUILDKITE_SPLITTER_IDENTIFIER", "123")
 	os.Setenv("BUILDKITE_SPLITTER_SUITE_TOKEN", "my_token")
-	os.Setenv("BUILDKITE_TEST_SPLITTER_CMD", "bin/rspec {{testExamples}}")
+	os.Setenv("BUILDKITE_SPLITTER_TEST_CMD", "bin/rspec {{testExamples}}")
 	defer os.Clearenv()
 
 	c := Config{}
@@ -43,7 +43,7 @@ func TestConfigReadFromEnv(t *testing.T) {
 func TestConfigReadFromEnv_MissingConfigWithDefault(t *testing.T) {
 	os.Setenv("BUILDKITE_SPLITTER_BASE_URL", "")
 	os.Setenv("BUILDKITE_SPLITTER_MODE", "")
-	os.Setenv("BUILDKITE_TEST_SPLITTER_CMD", "")
+	os.Setenv("BUILDKITE_SPLITTER_TEST_CMD", "")
 	os.Setenv("BUILDKITE_SPLITTER_IDENTIFIER", "")
 	os.Setenv("BUILDKITE_BUILD_ID", "123")
 	os.Setenv("BUILDKITE_STEP_ID", "456")

--- a/internal/runner/rspec.go
+++ b/internal/runner/rspec.go
@@ -14,6 +14,17 @@ import (
 // For now, Rspec provides rspec specific behaviour to execute
 // and report on tests in the Rspec framework.
 type Rspec struct {
+	TestCommand string
+}
+
+func NewRspec(testCommand string) Rspec {
+	if testCommand == "" {
+		testCommand = "bundle exec rspec {{testExamples}}"
+	}
+
+	return Rspec{
+		TestCommand: testCommand,
+	}
 }
 
 // GetFiles returns an array of file names, for files in
@@ -35,8 +46,8 @@ func (r Rspec) GetFiles() ([]string, error) {
 }
 
 // Command returns an exec.Cmd that will run the rspec command
-func (r Rspec) Command(testCases []string, testCommand string) (*exec.Cmd, error) {
-	commandName, commandArgs, err := r.commandNameAndArgs(testCases, testCommand)
+func (r Rspec) Command(testCases []string) (*exec.Cmd, error) {
+	commandName, commandArgs, err := r.commandNameAndArgs(testCases)
 	if err != nil {
 		return nil, err
 	}
@@ -67,8 +78,8 @@ func (Rspec) discoveryPattern() DiscoveryPattern {
 }
 
 // commandNameAndArgs returns the command name and arguments to run the Rspec tests
-func (Rspec) commandNameAndArgs(testCases []string, testCommand string) (string, []string, error) {
-	words, err := shellquote.Split(testCommand)
+func (r Rspec) commandNameAndArgs(testCases []string) (string, []string, error) {
+	words, err := shellquote.Split(r.TestCommand)
 	if err != nil {
 		return "", []string{}, err
 	}

--- a/internal/runner/rspec_test.go
+++ b/internal/runner/rspec_test.go
@@ -10,11 +10,11 @@ import (
 )
 
 func TestCommandNameAndArgs_WithInterpolationPlaceholder(t *testing.T) {
-	rspec := Rspec{}
 	testCases := []string{"spec/models/user_spec.rb", "spec/models/billing_spec.rb"}
 	testCommand := "bin/rspec --options {{testExamples}} --format"
+	rspec := NewRspec(testCommand)
 
-	gotName, gotArgs, err := rspec.commandNameAndArgs(testCases, testCommand)
+	gotName, gotArgs, err := rspec.commandNameAndArgs(testCases)
 	if err != nil {
 		t.Errorf("Rspec.commandNameAndArgs(%q, %q) error = %v", testCases, testCommand, err)
 	}
@@ -31,11 +31,11 @@ func TestCommandNameAndArgs_WithInterpolationPlaceholder(t *testing.T) {
 }
 
 func TestCommandNameAndArgs_WithoutInterpolationPlaceholder(t *testing.T) {
-	rspec := Rspec{}
 	testCases := []string{"spec/models/user_spec.rb", "spec/models/billing_spec.rb"}
 	testCommand := "bin/rspec --options --format"
+	rspec := NewRspec(testCommand)
 
-	gotName, gotArgs, err := rspec.commandNameAndArgs(testCases, testCommand)
+	gotName, gotArgs, err := rspec.commandNameAndArgs(testCases)
 	if err != nil {
 		t.Errorf("Rspec.commandNameAndArgs(%q, %q) error = %v", testCases, testCommand, err)
 	}
@@ -52,11 +52,11 @@ func TestCommandNameAndArgs_WithoutInterpolationPlaceholder(t *testing.T) {
 }
 
 func TestCommandNameAndArgs_InvalidTestCommand(t *testing.T) {
-	rspec := Rspec{}
 	testCases := []string{"spec/models/user_spec.rb", "spec/models/billing_spec.rb"}
 	testCommand := "bin/rspec --options ' {{testExamples}}"
+	rspec := NewRspec(testCommand)
 
-	gotName, gotArgs, err := rspec.commandNameAndArgs(testCases, testCommand)
+	gotName, gotArgs, err := rspec.commandNameAndArgs(testCases)
 
 	wantName := ""
 	wantArgs := []string{}

--- a/internal/runner/rspec_test.go
+++ b/internal/runner/rspec_test.go
@@ -9,6 +9,24 @@ import (
 	"github.com/kballard/go-shellquote"
 )
 
+func TestNewRspec_DefaultCommand(t *testing.T) {
+	defaultCommand := "bundle exec rspec {{testExamples}}"
+	rspec := NewRspec("")
+
+	if rspec.TestCommand != defaultCommand {
+		t.Errorf("rspec.TestCommand = %q, want %q", rspec.TestCommand, defaultCommand)
+	}
+}
+
+func TestNewRspec_CustomCommand(t *testing.T) {
+	customCommand := "bin/rspec --options {{testExamples}} --format"
+	rspec := NewRspec(customCommand)
+
+	if rspec.TestCommand != customCommand {
+		t.Errorf("rspec.TestCommand = %q, want %q", rspec.TestCommand, customCommand)
+	}
+}
+
 func TestCommandNameAndArgs_WithInterpolationPlaceholder(t *testing.T) {
 	testCases := []string{"spec/models/user_spec.rb", "spec/models/billing_spec.rb"}
 	testCommand := "bin/rspec --options {{testExamples}} --format"

--- a/main.go
+++ b/main.go
@@ -23,8 +23,14 @@ import (
 var Version = ""
 
 func main() {
+	// get config
+	cfg, err := config.New()
+	if err != nil {
+		logErrorAndExit(16, "Invalid configuration: %v", err)
+	}
+
 	// TODO: detect test runner and use appropriate runner
-	testRunner := runner.Rspec{}
+	testRunner := runner.NewRspec(cfg.TestCommand)
 
 	versionFlag := flag.Bool("version", false, "print version information")
 
@@ -49,12 +55,6 @@ func main() {
 		files = fs
 	}
 
-	// get config
-	cfg, err := config.New()
-	if err != nil {
-		logErrorAndExit(16, "Invalid configuration: %v", err)
-	}
-
 	// get plan
 	ctx := context.Background()
 	// We expect the whole test plan fetching process takes no more than 60 seconds.
@@ -76,9 +76,9 @@ func main() {
 		runnableTests = append(runnableTests, testCase.Path)
 	}
 
-	cmd, err := testRunner.Command(runnableTests, cfg.TestCommand)
+	cmd, err := testRunner.Command(runnableTests)
 	if err != nil {
-		logErrorAndExit(16, "Couldn't process test command: %q, %v", cfg.TestCommand, err)
+		logErrorAndExit(16, "Couldn't process test command: %q, %v", testRunner.TestCommand, err)
 	}
 
 	if err := cmd.Start(); err != nil {


### PR DESCRIPTION
### ⚠️ BREAKING CHANGES

### Description
Currently, the default test command is set inside the `config` package using Rspec default command. Since we will be adding support to other test runners (frameworks), we need to move this inside the `Rspec` struct.

I also store the `testCommand` as the property of Rspec struct so all functions can have access the value without having to pass the command every time.

### Testing

<!--
Call out any additional testing (beyond the automated tests) you felt was necessary and the results, e.g. running it manually, or running as part of another pipeline.
-->
It's worth testing test-splitter with and without custom test command.