### PR TITLE
Add debug mode to log the http request and response 

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,8 @@ package config
 type Config struct {
 	// AccessToken is the access token for the API.
 	AccessToken string
+	// DebugEnabled is a flag to enable debug logging.
+	DebugEnabled bool
 	// Identifier is the identifier of the build.
 	Identifier string
 	// Mode is the mode of the test splitter.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -19,6 +19,7 @@ func setEnv(t *testing.T) {
 	os.Setenv("BUILDKITE_API_ACCESS_TOKEN", "my_token")
 	os.Setenv("BUILDKITE_ORGANIZATION_SLUG", "my_org")
 	os.Setenv("BUILDKITE_SPLITTER_SUITE_SLUG", "my_suite")
+	os.Setenv("BUILDKITE_SPLITTER_DEBUG_ENABLED", "true")
 }
 
 func TestNewConfig(t *testing.T) {
@@ -40,6 +41,7 @@ func TestNewConfig(t *testing.T) {
 		AccessToken:      "my_token",
 		OrganizationSlug: "my_org",
 		SuiteSlug:        "my_suite",
+		DebugEnabled:     true,
 	}
 
 	if diff := cmp.Diff(c, want); diff != "" {
@@ -62,6 +64,7 @@ func TestNewConfig_MissingConfigWithDefault(t *testing.T) {
 	os.Unsetenv("BUILDKITE_SPLITTER_MODE")
 	os.Unsetenv("BUILDKITE_SPLITTER_BASE_URL")
 	os.Unsetenv("BUILDKITE_SPLITTER_TEST_CMD")
+	os.Unsetenv("BUILDKITE_SPLITTER_DEBUG_ENABLED")
 	defer os.Clearenv()
 
 	c, err := New()
@@ -78,6 +81,7 @@ func TestNewConfig_MissingConfigWithDefault(t *testing.T) {
 		AccessToken:      "my_token",
 		OrganizationSlug: "my_org",
 		SuiteSlug:        "my_suite",
+		DebugEnabled:     false,
 	}
 
 	if diff := cmp.Diff(c, want); diff != "" {

--- a/internal/config/read.go
+++ b/internal/config/read.go
@@ -13,6 +13,7 @@ import (
 //
 // Currently, it reads the following environment variables:
 // - BUILDKITE_API_ACCESS_TOKEN (AccessToken)
+// - BUILDKITE_SPLITTER_DEBUG_ENABLED (DebugEnabled)
 // - BUILDKITE_ORGANIZATION_SLUG (OrganizationSlug)
 // - BUILDKITE_PARALLEL_JOB_COUNT (Parallelism)
 // - BUILDKITE_PARALLEL_JOB (NodeIndex)
@@ -36,6 +37,7 @@ func (c *Config) readFromEnv() error {
 	c.ServerBaseUrl = getEnvWithDefault("BUILDKITE_SPLITTER_BASE_URL", "https://api.buildkite.com")
 	c.Mode = getEnvWithDefault("BUILDKITE_SPLITTER_MODE", "static")
 	c.TestCommand = os.Getenv("BUILDKITE_SPLITTER_TEST_CMD")
+	c.DebugEnabled = os.Getenv("BUILDKITE_SPLITTER_DEBUG_ENABLED") == "true"
 
 	MaxRetries, err := getIntEnvWithDefault("BUILDKITE_SPLITTER_RETRY_COUNT", 0)
 	c.MaxRetries = MaxRetries

--- a/main.go
+++ b/main.go
@@ -180,6 +180,7 @@ func fetchOrCreateTestPlan(ctx context.Context, cfg config.Config, files []strin
 		ServerBaseUrl:    cfg.ServerBaseUrl,
 		AccessToken:      cfg.AccessToken,
 		OrganizationSlug: cfg.OrganizationSlug,
+		DebugEnabled:     cfg.DebugEnabled,
 	})
 
 	// Fetch the plan from the server's cache.


### PR DESCRIPTION
### Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->
To help troubleshooting test splitter client, we want to log each request and response to/from the server. The logs should only be displayed when debug mode is enabled, and should redact any sensitive information (e.g. API token).

### Testing

<!--
Call out any additional testing (beyond the automated tests) you felt was necessary and the results, e.g. running it manually, or running as part of another pipeline.
-->
Run `BUILDKITE_SPLITTER_DEBUG_ENABLED=true ./test-splitter`, and check if each http request/response is printed.