### PR TITLE
Remove "files" arg for Test Splitter

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,7 +11,6 @@ import (
 	"os/exec"
 	"os/signal"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/buildkite/test-splitter/internal/api"
@@ -35,24 +34,16 @@ func main() {
 	versionFlag := flag.Bool("version", false, "print version information")
 
 	// Gathering files
-	filesFlag := flag.String("files", "", "string of file names for splitting")
 	flag.Parse()
-
-	var files []string
 
 	if *versionFlag {
 		fmt.Println(Version)
 		os.Exit(0)
 	}
 
-	if *filesFlag != "" {
-		files = strings.Split(*filesFlag, ",")
-	} else {
-		fs, err := testRunner.GetFiles()
-		if err != nil {
-			logErrorAndExit(16, "Couldn't get files: %v", err)
-		}
-		files = fs
+	files, err := testRunner.GetFiles()
+	if err != nil {
+		logErrorAndExit(16, "Couldn't get files: %v", err)
 	}
 
 	// get plan


### PR DESCRIPTION
### Description

This PR removes the feature for supporting a files flag. 

### Context

We had a brainstorm meeting for test splitter client quick wins this week. We decided to remove the files arg from the test splitter before launch.


### Testing

I tested the changes locally, the test splitter is working as expected