### PR TITLE
Use custom User-Agents for requests.

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -1,7 +1,9 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
+	"runtime"
 )
 
 // client is a client for the test splitter API.
@@ -17,16 +19,19 @@ type ClientConfig struct {
 	AccessToken      string
 	OrganizationSlug string
 	ServerBaseUrl    string
+	Version          string
 }
 
 // authTransport is a middleware for the HTTP client.
 type authTransport struct {
 	accessToken string
+	version     string
 }
 
 // RoundTrip adds the Authorization header to all requests made by the HTTP client.
 func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req.Header.Set("Authorization", "Bearer "+t.accessToken)
+	req.Header.Set("User-Agent", fmt.Sprintf("Buildkite Test Splitter/%s (%s/%s)", t.version, runtime.GOOS, runtime.GOARCH))
 	return http.DefaultTransport.RoundTrip(req)
 }
 
@@ -36,6 +41,7 @@ func NewClient(cfg ClientConfig) *client {
 	httpClient := &http.Client{
 		Transport: &authTransport{
 			accessToken: cfg.AccessToken,
+			version:     cfg.Version,
 		},
 	}
 

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -49,5 +50,27 @@ func TestHttpClient_AttachAccessTokenToRequest(t *testing.T) {
 
 	if resp.Request.Header.Get("Authorization") != "Bearer asdf1234" {
 		t.Errorf("Request Authorization header = %v, want %v", resp.Request.Header.Get("Authorization"), "Bearer asdf1234")
+	}
+}
+
+func TestHttpClient_AttachUserAgentToRequest(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer svr.Close()
+
+	// Create a new client with the given configuration.
+	cfg := ClientConfig{
+		AccessToken:      "asdf1234",
+		OrganizationSlug: "my-org",
+		ServerBaseUrl:    svr.URL,
+		Version:          "0.5.1",
+	}
+
+	c := NewClient(cfg)
+	resp, _ := c.httpClient.Get(svr.URL)
+
+	if !strings.Contains(resp.Request.Header.Get("User-Agent"), "Buildkite Test Splitter/0.5.1") {
+		t.Errorf("User-agent header = %v, want %v", resp.Request.Header.Get("User-Agent"), "Buildkite Test Splitter/0.5.1 ...")
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,8 @@ type Config struct {
 	TestCommand string
 	// MaxRetries is the maximum number of retries for a failed test.
 	MaxRetries int
+	// Version is the current splitter version
+	Version string
 }
 
 // New wraps the readFromEnv and validate functions to create a new Config struct.

--- a/main.go
+++ b/main.go
@@ -174,6 +174,7 @@ func fetchOrCreateTestPlan(ctx context.Context, cfg config.Config, files []strin
 		ServerBaseUrl:    cfg.ServerBaseUrl,
 		AccessToken:      cfg.AccessToken,
 		OrganizationSlug: cfg.OrganizationSlug,
+		Version:          cfg.Version,
 	})
 
 	// Fetch the plan from the server's cache.


### PR DESCRIPTION
### Description

Debugging of the test splitter is currently quite difficult. This PR adds a small step in the right direction, by introducing a custom User-Agent for the splitter in the format:

`Buildkite Test Splitter/<version> (goos/arch)`

### Context

[here](https://buildkite-corp.slack.com/archives/C05NKQQTSGM/p1717551599831339)
and 
https://linear.app/buildkite/issue/TAT-179/tsc-to-submit-custom-user-agent

### Changes

Simples.

### Testing

Inspect headers on backend.