### PR TITLE
Rename BUILDKITE_API_ACCESS_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Buildkite Test Splitter
 
-## Migrating to 0.5.0
+## Migrating from 0.4.0
+
 0.5.0 introduces authentication mechanism changes. Previously, the test splitter used a suite token set in the `BUILDKITE_SPLITTER_SUITE_TOKEN` environment variable to authenticate.
 From version 0.5.0 onwards, you will need to use a Buildkite API Access Token with the `read_suites`, `read_test_plan`, and `write_test_plan` scopes.
-The API access token can be created from your [personal setting page](https://buildkite.com/user/api-access-tokens) in Buildkite, and needs to be configured for the test splitter using the `BUILDKITE_API_ACCESS_TOKEN` environment variable.
+The API access token can be created from your [personal setting page](https://buildkite.com/user/api-access-tokens) in Buildkite, and needs to be configured for the test splitter using the `BUILDKITE_SPLITTER_API_ACCESS_TOKEN` environment variable.
 
 Additionally, you will need to ensure that the organization and suite slugs are present in the environment. The organization slug is readily available in your Pipeline environment as `BUILDKITE_ORGANIZATION_SLUG` so you do not have to set it manually, however, you will need to pass this variable to the docker container if you are using docker-compose plugin.
 The suite slug needs to be manually configured using the `BUILDKITE_SPLITTER_SUITE_SLUG` environment variable. You can find the suite slug in the url for your suite, for example, the slug for the url: https://buildkite.com/organizations/my-organization/analytics/suites/my-suite?branch=main is `my-suite`. 
@@ -26,10 +27,10 @@ The available Go binaries
 
 | Environment Variable | Default Value | Description |
 | ---- | ---- | ----------- |
-| `BUILDKITE_API_ACCESS_TOKEN ` | - | Required, Buildkite API access token with `read_suites`, `read_test_plan`, and `write_test_plan` scopes. You can create access token from [Personal Settings](https://buildkite.com/user/api-access-tokens) in Buildkite |
 | `BUILDKITE_ORGANIZATION_SLUG` | - | Required, the slug of your Buildkite organization. This is available in your pipeline environment, so you don't need to set it manually |
 | `BUILDKITE_PARALLEL_JOB_COUNT` | - | Required, total number of parallelism. |
 | `BUILDKITE_PARALLEL_JOB` | - | Required, test plan for specific node |
+| `BUILDKITE_SPLITTER_API_ACCESS_TOKEN ` | - | Required, Buildkite API access token with `read_suites`, `read_test_plan`, and `write_test_plan` scopes. You can create access token from [Personal Settings](https://buildkite.com/user/api-access-tokens) in Buildkite |
 | `BUILDKITE_SPLITTER_IDENTIFIER` | `BUILDKITE_BUILD_ID/BUILDKITE_STEP_ID` | Optional. Test Splitter uses the identifier to store and fetch the test plan and must be unique for each build and steps group. By default it will use a composite of `BUILDKITE_BUILD_ID` and `BUILDKITE_STEP_ID`, but it can be overridden by specifying the `BUILDKITE_SPLITTER_IDENTIFIER`. `BUILDKITE_BUILD_ID` and `BUILDKITE_STEP_ID` must be accessible by the client when using the default. |
 | `BUILDKITE_SPLITTER_TEST_CMD` | `bundle exec rspec {{testExamples}}` | Optional, test command for running your tests. Test splitter will fill in the `{{testExamples}}` placeholder with the test splitting results |
 | `BUILDKITE_SPLITTER_TEST_FILE_PATTERN` | `spec/**/*_spec.rb` | Optional, glob pattern for discovering test files that need to be executed. </br> *It accepts pattern syntax supported by [zzglob](https://github.com/DrJosh9000/zzglob?tab=readme-ov-file#pattern-syntax) library*. |
@@ -39,7 +40,7 @@ The available Go binaries
 
 For most use cases, Test Splitter should work out of the box due to the default values available from your Buildkite environment.
 
-However, you'll have to set `BUILDKITE_API_ACCESS_TOKEN` and `BUILDKITE_SPLITTER_SUITE_SLUG`.
+However, you'll have to set `BUILDKITE_SPLITTER_API_ACCESS_TOKEN` and `BUILDKITE_SPLITTER_SUITE_SLUG`.
 
 You can also set the `BUILDKITE_SPLITTER_TEST_FILE_PATTERN` or `BUILDKITE_SPLITTER_TEST_FILE_EXCLUDE_PATTERN` if you need to filter the tests selected for execution.
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -12,11 +12,11 @@ func setEnv(t *testing.T) {
 	t.Helper()
 	os.Setenv("BUILDKITE_PARALLEL_JOB_COUNT", "60")
 	os.Setenv("BUILDKITE_PARALLEL_JOB", "7")
+	os.Setenv("BUILDKITE_SPLITTER_API_ACCESS_TOKEN", "my_token")
 	os.Setenv("BUILDKITE_SPLITTER_BASE_URL", "https://build.kite")
 	os.Setenv("BUILDKITE_SPLITTER_MODE", "static")
 	os.Setenv("BUILDKITE_SPLITTER_IDENTIFIER", "xyz")
 	os.Setenv("BUILDKITE_SPLITTER_TEST_CMD", "bin/rspec {{testExamples}}")
-	os.Setenv("BUILDKITE_API_ACCESS_TOKEN", "my_token")
 	os.Setenv("BUILDKITE_ORGANIZATION_SLUG", "my_org")
 	os.Setenv("BUILDKITE_SPLITTER_SUITE_SLUG", "my_suite")
 }
@@ -88,7 +88,7 @@ func TestNewConfig_MissingConfigWithDefault(t *testing.T) {
 func TestNewConfig_InvalidConfig(t *testing.T) {
 	setEnv(t)
 	os.Setenv("BUILDKITE_SPLITTER_MODE", "dynamic")
-	os.Unsetenv("BUILDKITE_API_ACCESS_TOKEN")
+	os.Unsetenv("BUILDKITE_SPLITTER_API_ACCESS_TOKEN")
 	defer os.Clearenv()
 
 	_, err := New()

--- a/internal/config/read.go
+++ b/internal/config/read.go
@@ -12,10 +12,10 @@ import (
 // set default values for ServerBaseUrl and Mode if they are not set.
 //
 // Currently, it reads the following environment variables:
-// - BUILDKITE_API_ACCESS_TOKEN (AccessToken)
 // - BUILDKITE_ORGANIZATION_SLUG (OrganizationSlug)
 // - BUILDKITE_PARALLEL_JOB_COUNT (Parallelism)
 // - BUILDKITE_PARALLEL_JOB (NodeIndex)
+// - BUILDKITE_SPLITTER_API_ACCESS_TOKEN (AccessToken)
 // - BUILDKITE_SPLITTER_IDENTIFIER (Identifier)
 // - BUILDKITE_SPLITTER_BASE_URL (ServerBaseUrl)
 // - BUILDKITE_SPLITTER_MODE (Mode)
@@ -28,7 +28,7 @@ import (
 func (c *Config) readFromEnv() error {
 	var errs InvalidConfigError
 
-	c.AccessToken = os.Getenv("BUILDKITE_API_ACCESS_TOKEN")
+	c.AccessToken = os.Getenv("BUILDKITE_SPLITTER_API_ACCESS_TOKEN")
 	c.OrganizationSlug = os.Getenv("BUILDKITE_ORGANIZATION_SLUG")
 	c.SuiteSlug = os.Getenv("BUILDKITE_SPLITTER_SUITE_SLUG")
 

--- a/internal/config/read_test.go
+++ b/internal/config/read_test.go
@@ -15,7 +15,7 @@ func TestConfigReadFromEnv(t *testing.T) {
 	os.Setenv("BUILDKITE_SPLITTER_MODE", "static")
 	os.Setenv("BUILDKITE_SPLITTER_IDENTIFIER", "123")
 	os.Setenv("BUILDKITE_SPLITTER_TEST_CMD", "bin/rspec {{testExamples}}")
-	os.Setenv("BUILDKITE_API_ACCESS_TOKEN", "my_token")
+	os.Setenv("BUILDKITE_SPLITTER_API_ACCESS_TOKEN", "my_token")
 	os.Setenv("BUILDKITE_ORGANIZATION_SLUG", "my_org")
 	os.Setenv("BUILDKITE_SPLITTER_SUITE_SLUG", "my_suite")
 	os.Setenv("BUILDKITE_SPLITTER_RETRY_COUNT", "3")


### PR DESCRIPTION
### Description

BUILDKITE_API_ACCESS_TOKEN is a pretty confusing name for a few reasons:
1. We want to encourage the principle of least privilege, and having a generically-named variable such as this suggests we support the opposite position.
2. We've had a clash where a customer's splitter did something unexpected because of an overlap in the names.

So we're renaming it to BUILDKITE_SPLITTER_API_ACCESS_TOKEN to be more specific.

### Context

https://linear.app/buildkite/issue/TAT-178/rename-buildkite-api-access-token

### Changes

Self-explanitory

### Testing

None.