### PR TITLE
Improve server side error handling

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -132,7 +132,7 @@ func (c *Client) DoWithRetry(ctx context.Context, req httpRequest, v interface{}
 
 		debug.Printf("Response code %d", resp.StatusCode)
 
-		// If we get a 429, we should return and rety after the rate limit resets.
+		// If we get a 429, we should return and retry after the rate limit resets.
 		if resp.StatusCode == http.StatusTooManyRequests {
 			if rateLimitReset, err := strconv.Atoi(resp.Header.Get("RateLimit-Reset")); err == nil {
 				r.SetNextInterval(time.Duration(rateLimitReset) * time.Second)

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -1,10 +1,21 @@
 package api
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"runtime"
+	"strconv"
+	"time"
+
+	"github.com/buildkite/roko"
+	"github.com/buildkite/test-splitter/internal/debug"
 )
+
+var ErrRetryTimeout = errors.New("request retry timeout")
 
 // client is a client for the test splitter API.
 // It contains the organization slug, server base URL, and an HTTP client.
@@ -32,7 +43,6 @@ type authTransport struct {
 func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req.Header.Set("Authorization", "Bearer "+t.accessToken)
 	req.Header.Set("User-Agent", fmt.Sprintf("Buildkite Test Splitter/%s (%s/%s)", t.version, runtime.GOOS, runtime.GOARCH))
-
 	return http.DefaultTransport.RoundTrip(req)
 }
 
@@ -51,4 +61,81 @@ func NewClient(cfg ClientConfig) *Client {
 		ServerBaseUrl:    cfg.ServerBaseUrl,
 		httpClient:       httpClient,
 	}
+}
+
+var retryTimeout = 130 * time.Second
+var initialDelay = 3000 * time.Millisecond
+
+// DoWithRetry sends http request with retries.
+// It retries on request errors (e.g. redirects, protocol errors), 429, and 5xx status codes.
+// It uses an exponential backoff strategy with jitter, except for 429 status codes where it waits until the rate limit resets.
+// DeadlineExceeded error is returned if the request cannot be fulfilled within the retry timeout which is 130 seconds.
+// 130 seconds is chosen to allow for 2 API rate limit windows.
+func (c *Client) DoWithRetry(ctx context.Context, method string, url string, body any) (*http.Response, error) {
+	r := roko.NewRetrier(
+		roko.TryForever(),
+		roko.WithStrategy(roko.ExponentialSubsecond(initialDelay)),
+		roko.WithJitter(),
+	)
+
+	retryContext, cancel := context.WithTimeout(ctx, retryTimeout)
+	defer cancel()
+
+	debug.Printf("Sending request %s %s", method, url)
+	resp, err := roko.DoFunc(retryContext, r, func(r *roko.Retrier) (*http.Response, error) {
+		if r.AttemptCount() > 0 {
+			debug.Printf("Retrying requests, attempt %d", r.AttemptCount())
+		}
+
+		reqBody, err := json.Marshal(body)
+		if err != nil {
+			r.Break()
+			return nil, fmt.Errorf("converting body to json: %w", err)
+		}
+
+		req, err := http.NewRequest(method, url, bytes.NewBuffer(reqBody))
+		if err != nil {
+			r.Break()
+			return nil, fmt.Errorf("creating request: %w", err)
+		}
+		req.Header.Add("Content-Type", "application/json")
+
+		resp, err := c.httpClient.Do(req)
+
+		// If we get an error before getting a response,
+		// which means there is a redirect or protocol error,
+		// we should retry.
+		if err != nil {
+			debug.Printf("Error sending request: %v", err)
+			return nil, err
+		}
+
+		debug.Printf("Response code %d", resp.StatusCode)
+
+		// If we get a 429, we should wait until the rate limit resets and retry.
+		if resp.StatusCode == http.StatusTooManyRequests {
+			if rateLimitReset, err := strconv.Atoi(resp.Header.Get("RateLimit-Reset")); err == nil {
+				r.SetNextInterval(time.Duration(rateLimitReset) * time.Second)
+			}
+			return resp, fmt.Errorf("response code: 429")
+		}
+
+		// If we get a 5xx, we should retry
+		if resp.StatusCode >= 500 {
+			return resp, fmt.Errorf("response code: %d", resp.StatusCode)
+		}
+
+		// If we get a 4xx, we should not retry
+		if resp.StatusCode >= 400 {
+			r.Break()
+		}
+
+		return resp, nil
+	})
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		return resp, ErrRetryTimeout
+	}
+
+	return resp, err
 }

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -1,10 +1,15 @@
 package api
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestNewClient(t *testing.T) {
@@ -72,5 +77,187 @@ func TestHttpClient_AttachUserAgentToRequest(t *testing.T) {
 
 	if !strings.Contains(resp.Request.Header.Get("User-Agent"), "Buildkite Test Splitter/0.5.1") {
 		t.Errorf("User-agent header = %v, want %v", resp.Request.Header.Get("User-Agent"), "Buildkite Test Splitter/0.5.1 ...")
+	}
+}
+
+func TestDoWithRetry_Success(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		io.Copy(w, r.Body)
+	}))
+	defer svr.Close()
+
+	cfg := ClientConfig{
+		ServerBaseUrl: svr.URL,
+	}
+	c := NewClient(cfg)
+
+	resp, err := c.DoWithRetry(context.Background(), http.MethodPost, svr.URL, map[string]string{"message": "hello"})
+
+	if err != nil {
+		t.Errorf("DoWithRetry(ctx, req) error = %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("DoWithRetry(ctx, req) status code = %v, want %v", resp.StatusCode, http.StatusOK)
+	}
+
+	responseBody, _ := io.ReadAll(resp.Body)
+	want := `{"message":"hello"}`
+	if string(responseBody) != want {
+		t.Errorf("DoWithRetry(ctx, req) body = %v, want %v", string(responseBody), want)
+	}
+}
+
+func TestDoWithRetry_RequestError(t *testing.T) {
+	originalTimeout := retryTimeout
+	retryTimeout = 300 * time.Millisecond
+	t.Cleanup(func() {
+		retryTimeout = originalTimeout
+	})
+
+	cfg := ClientConfig{
+		AccessToken:      "asdf1234",
+		OrganizationSlug: "my-org",
+	}
+
+	c := NewClient(cfg)
+	resp, err := c.DoWithRetry(context.Background(), http.MethodGet, "http://build.kite", nil)
+
+	fmt.Println(resp)
+
+	// it retries the request and returns ErrRetryTimeout with nil response.
+	if !errors.Is(err, ErrRetryTimeout) {
+		t.Errorf("DoWithRetry(ctx, req) error = %v, want %v", err, ErrRetryTimeout)
+	}
+
+	if resp != nil {
+		t.Errorf("DoWithRetry(ctx, req) = %v, want nil", resp)
+	}
+}
+
+func TestDoWithRetry_429(t *testing.T) {
+	originalTimeout := retryTimeout
+	retryTimeout = 2 * time.Second
+	t.Cleanup(func() {
+		retryTimeout = originalTimeout
+	})
+
+	callCount := 0
+
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("RateLimit-Reset", "1")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer svr.Close()
+
+	cfg := ClientConfig{
+		AccessToken:      "asdf1234",
+		OrganizationSlug: "my-org",
+		ServerBaseUrl:    svr.URL,
+	}
+
+	c := NewClient(cfg)
+	resp, err := c.DoWithRetry(context.Background(), http.MethodGet, svr.URL, nil)
+
+	// it retries the request and returns ErrRetryTimeout with the 429 status code.
+	if callCount != 2 {
+		t.Errorf("http request count = %v, want %v", callCount, 2)
+	}
+
+	if !errors.Is(err, ErrRetryTimeout) {
+		t.Errorf("DoWithRetry(ctx, req) error = %v, want %v", err, ErrRetryTimeout)
+	}
+
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("DoWithRetry(ctx, req) status code = %v, want %v", resp.StatusCode, http.StatusTooManyRequests)
+	}
+}
+
+func TestDoWithRetry_500(t *testing.T) {
+	originalTimeout := retryTimeout
+	originalInitialDelay := initialDelay
+
+	retryTimeout = 2 * time.Second
+	initialDelay = 100 * time.Millisecond
+	t.Cleanup(func() {
+		retryTimeout = originalTimeout
+		initialDelay = originalInitialDelay
+	})
+
+	callCount := 0
+
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer svr.Close()
+
+	cfg := ClientConfig{
+		AccessToken:      "asdf1234",
+		OrganizationSlug: "my-org",
+		ServerBaseUrl:    svr.URL,
+	}
+
+	c := NewClient(cfg)
+
+	resp, err := c.DoWithRetry(context.Background(), http.MethodPost, svr.URL, nil)
+
+	// it retries the request and returns ErrRetryTimeout with the 500 status code.
+	if callCount < 2 {
+		t.Errorf("http request count = %v, want at least 2", callCount)
+	}
+
+	if !errors.Is(err, ErrRetryTimeout) {
+		t.Errorf("DoWithRetry(ctx, req) error = %v, want %v", err, ErrRetryTimeout)
+	}
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("DoWithRetry(ctx, req) status code = %v, want %v", resp.StatusCode, http.StatusInternalServerError)
+	}
+}
+
+func TestDoWithRetry_403(t *testing.T) {
+	originalTimeout := retryTimeout
+	originalInitialDelay := initialDelay
+
+	retryTimeout = 500 * time.Millisecond
+	initialDelay = 100 * time.Millisecond
+
+	t.Cleanup(func() {
+		retryTimeout = originalTimeout
+		initialDelay = originalInitialDelay
+	})
+
+	callCount := 0
+
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer svr.Close()
+
+	cfg := ClientConfig{
+		AccessToken:      "asdf1234",
+		OrganizationSlug: "my-org",
+		ServerBaseUrl:    svr.URL,
+	}
+
+	c := NewClient(cfg)
+	resp, err := c.DoWithRetry(context.Background(), http.MethodGet, svr.URL, nil)
+
+	// it returns immediately with the 403 status code.
+	if callCount > 1 {
+		t.Errorf("http request count = %v, want 1", callCount)
+	}
+
+	if err != nil {
+		t.Errorf("DoWithRetry(ctx, req) error = %v", err)
+	}
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("DoWithRetry(ctx, req) status code = %v, want %v", resp.StatusCode, http.StatusForbidden)
 	}
 }

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -192,7 +192,7 @@ func TestDoWithRetry_500(t *testing.T) {
 	originalTimeout := retryTimeout
 	originalInitialDelay := initialDelay
 
-	retryTimeout = 700 * time.Millisecond
+	retryTimeout = 1000 * time.Millisecond
 	initialDelay = 1 * time.Millisecond
 	t.Cleanup(func() {
 		retryTimeout = originalTimeout

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -192,7 +192,7 @@ func TestDoWithRetry_500(t *testing.T) {
 	originalTimeout := retryTimeout
 	originalInitialDelay := initialDelay
 
-	retryTimeout = 500 * time.Millisecond
+	retryTimeout = 700 * time.Millisecond
 	initialDelay = 1 * time.Millisecond
 	t.Cleanup(func() {
 		retryTimeout = originalTimeout

--- a/internal/api/create_test_plan.go
+++ b/internal/api/create_test_plan.go
@@ -1,21 +1,11 @@
 package api
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
-	"io"
 	"net/http"
-	"time"
 
-	"github.com/buildkite/roko"
 	"github.com/buildkite/test-splitter/internal/plan"
-)
-
-var (
-	errInvalidRequest = errors.New("request was invalid")
 )
 
 type TestPlanParamsTest struct {
@@ -31,95 +21,20 @@ type TestPlanParams struct {
 	Tests       TestPlanParamsTest `json:"tests"`
 }
 
-// CreateTestPlan creates a test plan from the service, including retries.
+// CreateTestPlan creates a test plan from the server.
+// ErrRetryTimeout is returned if the client failed to communicate with the server after exceeding the retry limit.
 func (c Client) CreateTestPlan(ctx context.Context, suiteSlug string, params TestPlanParams) (plan.TestPlan, error) {
-	// Retry using exponential backoff offerred by roko
-	// https://pkg.go.dev/github.com/buildkite/roko#ExponentialSubsecond
-	//
-	// The formula defined by roko is: delay = initialDelay ** (retries/16 + 1)
-	// Example of 3s initial delay growing over 6 attempts:
-	//  3s    → 5s    → 8s   → 13s   → 22s
-	// for a total retry delay of 51 seconds between attempts.
-	// Each request times out after 12 seconds, chosen to provide some
-	// headroom on top of the goal p99 time to fetch of 10s.
-	// So in the worst case only 3 full attempts and 1 partial attempt
-	// may be made to fetch a test plan before the overall 70 second
-	// timeout.
-
-	// Initial retry delay for fetching test plans.
-	// This is a variable so it can be overridden in tests.
-	// See comment in FetchTestPlan.
-	const initialDelay = 3000 * time.Millisecond
-
-	r := roko.NewRetrier(
-		roko.TryForever(),
-		roko.WithStrategy(roko.ExponentialSubsecond(initialDelay)),
-		roko.WithJitter(),
-	)
-	testPlan, err := roko.DoFunc(ctx, r, func(r *roko.Retrier) (plan.TestPlan, error) {
-		tp, err := c.tryCreateTestPlan(ctx, suiteSlug, params)
-		// Don't retry if the request was invalid
-		if errors.Is(err, errInvalidRequest) {
-			r.Break()
-		}
-		return tp, err
-	})
-
-	return testPlan, err
-}
-
-// tryCreateTestPlan creates a test plan from the service.
-func (c Client) tryCreateTestPlan(ctx context.Context, suiteSlug string, params TestPlanParams) (plan.TestPlan, error) {
-	// convert params to json string
-	requestBody, err := json.Marshal(params)
-	if err != nil {
-		return plan.TestPlan{}, fmt.Errorf("converting params to JSON: %w", err)
-	}
-
-	// See above for explanation of 15 seconds.
-	reqCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
-	defer cancel()
-
-	// create request
 	postUrl := fmt.Sprintf("%s/v2/analytics/organizations/%s/suites/%s/test_plan", c.ServerBaseUrl, c.OrganizationSlug, suiteSlug)
-	r, err := http.NewRequestWithContext(reqCtx, "POST", postUrl, bytes.NewBuffer(requestBody))
-	if err != nil {
-		return plan.TestPlan{}, fmt.Errorf("creating request: %w", err)
-	}
-	r.Header.Add("Content-Type", "application/json")
 
-	// send request
-	resp, err := c.httpClient.Do(r)
-	if err != nil {
-		return plan.TestPlan{}, fmt.Errorf("sending request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	// read response
-	responseBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return plan.TestPlan{}, fmt.Errorf("reading response body: %w", err)
-	}
-
-	switch {
-	case resp.StatusCode == http.StatusOK:
-		// This is our happy path
-
-	case resp.StatusCode >= 400 && resp.StatusCode < 500:
-		var errorResp errorResponse
-		json.Unmarshal(responseBody, &errorResp)
-		return plan.TestPlan{}, fmt.Errorf("%w: server response: %d %s", errInvalidRequest, resp.StatusCode, errorResp.Message)
-	case resp.StatusCode >= 500 && resp.StatusCode < 600:
-		var errorResp errorResponse
-		json.Unmarshal(responseBody, &errorResp)
-		return plan.TestPlan{}, fmt.Errorf("server response: %d %s", resp.StatusCode, errorResp.Message)
-	}
-
-	// parse response
 	var testPlan plan.TestPlan
-	err = json.Unmarshal(responseBody, &testPlan)
+	_, err := c.DoWithRetry(ctx, httpRequest{
+		Method: http.MethodPost,
+		URL:    postUrl,
+		Body:   params,
+	}, &testPlan)
+
 	if err != nil {
-		return plan.TestPlan{}, fmt.Errorf("parsing response: %w", err)
+		return plan.TestPlan{}, err
 	}
 
 	return testPlan, nil

--- a/internal/api/create_test_plan_test.go
+++ b/internal/api/create_test_plan_test.go
@@ -139,9 +139,11 @@ func TestCreateTestPlan(t *testing.T) {
 	}
 }
 
-func TestCreateTestPlan_Error4xx(t *testing.T) {
+func TestCreateTestPlan_BadRequest(t *testing.T) {
+	requestCount := 0
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(400)
+		requestCount++
+		http.Error(w, `{"message": "bad request"}`, http.StatusBadRequest)
 	}))
 	defer svr.Close()
 
@@ -155,41 +157,55 @@ func TestCreateTestPlan_Error4xx(t *testing.T) {
 
 	wantTestPlan := plan.TestPlan{}
 
-	if diff := cmp.Diff(got, wantTestPlan); diff != "" {
-		t.Errorf("CreateTestPlan(ctx, %v) diff (-got +want):\n%s", params, diff)
+	if requestCount > 1 {
+		t.Errorf("http request count = %v, want %d", requestCount, 1)
 	}
 
-	if !errors.Is(err, errInvalidRequest) {
-		t.Errorf("CreateTestPlan(ctx, %v) want %v got %v", params, errInvalidRequest, err)
+	if diff := cmp.Diff(got, wantTestPlan); diff != "" {
+		t.Errorf("CreateTestPlan() diff (-got +want):\n%s", diff)
+	}
+
+	if err.Error() != "bad request" {
+		t.Errorf("CreateTestPlan() error = %v, want %v", err, ErrRetryTimeout)
 	}
 }
 
-// Test the client keeps getting 5xx error until reached context deadline
-func TestCreateTestPlan_Timeout(t *testing.T) {
+func TestCreateTestPlan_InternalServerError(t *testing.T) {
+	originalTimeout := retryTimeout
+	originalInitialDelay := initialDelay
 
+	retryTimeout = 500 * time.Millisecond
+	initialDelay = 1 * time.Millisecond
+	t.Cleanup(func() {
+		retryTimeout = originalTimeout
+		initialDelay = originalInitialDelay
+	})
+
+	requestCount := 0
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(500)
+		requestCount++
+		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer svr.Close()
-
-	ctx := context.Background()
-	fetchCtx, cancel := context.WithTimeout(ctx, 1*time.Second)
-	defer cancel()
 
 	params := TestPlanParams{}
 	apiClient := NewClient(ClientConfig{
 		ServerBaseUrl: svr.URL,
 	})
 
-	got, err := apiClient.CreateTestPlan(fetchCtx, "my-suite", params)
+	got, err := apiClient.CreateTestPlan(context.Background(), "my-suite", params)
 
 	wantTestPlan := plan.TestPlan{}
 
-	if diff := cmp.Diff(got, wantTestPlan); diff != "" {
-		t.Errorf("CreateTestPlan(ctx, %v) diff (-got +want):\n%s", params, diff)
+	if requestCount < 2 {
+		t.Errorf("http request count = %v, want at least %d", requestCount, 2)
 	}
 
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Errorf("FetchTestPlan(ctx, %v) want %v, got %v", params, context.DeadlineExceeded, err)
+	if diff := cmp.Diff(got, wantTestPlan); diff != "" {
+		t.Errorf("CreateTestPlan() diff (-got +want):\n%s", diff)
+	}
+
+	if !errors.Is(err, ErrRetryTimeout) {
+		t.Errorf("CreateTestPlan() want %v, got %v", ErrRetryTimeout, err)
 	}
 }

--- a/internal/api/create_test_plan_test.go
+++ b/internal/api/create_test_plan_test.go
@@ -172,18 +172,12 @@ func TestCreateTestPlan_BadRequest(t *testing.T) {
 
 func TestCreateTestPlan_InternalServerError(t *testing.T) {
 	originalTimeout := retryTimeout
-	originalInitialDelay := initialDelay
-
-	retryTimeout = 500 * time.Millisecond
-	initialDelay = 1 * time.Millisecond
+	retryTimeout = 1 * time.Millisecond
 	t.Cleanup(func() {
 		retryTimeout = originalTimeout
-		initialDelay = originalInitialDelay
 	})
 
-	requestCount := 0
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestCount++
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer svr.Close()
@@ -196,10 +190,6 @@ func TestCreateTestPlan_InternalServerError(t *testing.T) {
 	got, err := apiClient.CreateTestPlan(context.Background(), "my-suite", params)
 
 	wantTestPlan := plan.TestPlan{}
-
-	if requestCount < 2 {
-		t.Errorf("http request count = %v, want at least %d", requestCount, 2)
-	}
 
 	if diff := cmp.Diff(got, wantTestPlan); diff != "" {
 		t.Errorf("CreateTestPlan() diff (-got +want):\n%s", diff)

--- a/internal/api/fetch_files_timing.go
+++ b/internal/api/fetch_files_timing.go
@@ -1,10 +1,8 @@
 package api
 
 import (
-	"bytes"
-	"encoding/json"
+	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"time"
 )
@@ -15,49 +13,24 @@ type fetchFilesTimingParams struct {
 
 // FetchFilesTiming fetches the timing of the requested files from the server.
 // The server only returns timings for the files that has been run before.
-func (c Client) FetchFilesTiming(suiteSlug string, files []string) (map[string]time.Duration, error) {
+// ErrRetryTimeout is returned if the client failed to communicate with the server after exceeding the retry limit.
+func (c Client) FetchFilesTiming(ctx context.Context, suiteSlug string, files []string) (map[string]time.Duration, error) {
 	url := fmt.Sprintf("%s/v2/analytics/organizations/%s/suites/%s/test_files", c.ServerBaseUrl, c.OrganizationSlug, suiteSlug)
 
-	requestBody, err := json.Marshal(fetchFilesTimingParams{
-		Paths: files,
-	})
-
-	if err != nil {
-		return nil, fmt.Errorf("converting params to JSON: %w", err)
-	}
-
-	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(requestBody))
-	req.Header.Add("Content-Type", "application/json")
-
-	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
-	}
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("sending request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	responseBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading response body: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		var errorResp errorResponse
-		json.Unmarshal(responseBody, &errorResp)
-		return nil, fmt.Errorf(errorResp.Message)
-	}
-
 	var filesTiming map[string]int
-	err = json.Unmarshal(responseBody, &filesTiming)
+	_, err := c.DoWithRetry(ctx, httpRequest{
+		Method: http.MethodPost,
+		URL:    url,
+		Body: fetchFilesTimingParams{
+			Paths: files,
+		},
+	}, &filesTiming)
+
 	if err != nil {
-		return nil, fmt.Errorf("parsing response: %w", err)
+		return nil, err
 	}
 
 	result := map[string]time.Duration{}
-
 	for path, duration := range filesTiming {
 		result[path] = time.Duration(duration * int(time.Millisecond))
 	}

--- a/internal/api/fetch_files_timing_test.go
+++ b/internal/api/fetch_files_timing_test.go
@@ -98,18 +98,12 @@ func TestFetchFilesTiming_BadRequest(t *testing.T) {
 
 func TestFetchFilesTiming_InternalServerError(t *testing.T) {
 	originalTimeout := retryTimeout
-	originalInitialDelay := initialDelay
-
-	retryTimeout = 500 * time.Millisecond
-	initialDelay = 1 * time.Millisecond
+	retryTimeout = 1 * time.Millisecond
 	t.Cleanup(func() {
 		retryTimeout = originalTimeout
-		initialDelay = originalInitialDelay
 	})
 
-	requestCount := 0
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestCount++
 		http.Error(w, `{"message": "something went wrong"}`, http.StatusInternalServerError)
 	}))
 	defer svr.Close()
@@ -121,10 +115,6 @@ func TestFetchFilesTiming_InternalServerError(t *testing.T) {
 
 	files := []string{"apple_spec.rb", "banana_spec.rb"}
 	_, err := c.FetchFilesTiming(context.Background(), "my-suite", files)
-
-	if requestCount < 2 {
-		t.Errorf("http request count = %v, want at least %d", requestCount, 2)
-	}
 
 	if !errors.Is(err, ErrRetryTimeout) {
 		t.Errorf("FetchFilesTiming() error = %v, want %v", err, ErrRetryTimeout)

--- a/internal/api/fetch_test_plan.go
+++ b/internal/api/fetch_test_plan.go
@@ -9,10 +9,6 @@ import (
 	"github.com/buildkite/test-splitter/internal/plan"
 )
 
-type errorResponse struct {
-	Message string `json:"message"`
-}
-
 // FetchTestPlan fetchs a test plan from the server.
 // If the plan is found, it returns the plan, otherwise it returns nil.
 // Error is returned if there is a client side failure or invalid request (400, 401, 403).

--- a/internal/api/fetch_test_plan.go
+++ b/internal/api/fetch_test_plan.go
@@ -1,56 +1,30 @@
 package api
 
 import (
-	"encoding/json"
+	"context"
 	"fmt"
-	"io"
 	"net/http"
 
 	"github.com/buildkite/test-splitter/internal/plan"
 )
 
 // FetchTestPlan fetchs a test plan from the server.
-// If the plan is found, it returns the plan, otherwise it returns nil.
-// Error is returned if there is a client side failure or invalid request (400, 401, 403).
-// Other server errors are ignored and treated as "not found".
-func (c Client) FetchTestPlan(suiteSlug string, identifier string) (*plan.TestPlan, error) {
+// ErrRetryTimeout is returned if the client failed to communicate with the server after exceeding the retry limit.
+func (c Client) FetchTestPlan(ctx context.Context, suiteSlug string, identifier string) (*plan.TestPlan, error) {
 	url := fmt.Sprintf("%s/v2/analytics/organizations/%s/suites/%s/test_plan?identifier=%s", c.ServerBaseUrl, c.OrganizationSlug, suiteSlug, identifier)
 
-	// send request
-	resp, err := c.httpClient.Get(url)
-	if err != nil {
-		return nil, fmt.Errorf("sending request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	switch resp.StatusCode {
-	case http.StatusOK:
-		// happy path
-	case http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden:
-		// treat following errors as client side errors because they are not recoverable.
-		// 400: Bad request (invalid request)
-		// 401: Unauthorized (invalid access token)
-		// 403: Forbidden (access token does not have required permissions)
-		responseBody, _ := io.ReadAll(resp.Body)
-		var errorResp errorResponse
-		json.Unmarshal(responseBody, &errorResp)
-		return nil, fmt.Errorf(errorResp.Message)
-	default:
-		// ignore other errors and treat them as "not found", so the client can proceed with creating a new plan.
-		return nil, nil
-	}
-
-	// read response
-	responseBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading response body: %w", err)
-	}
-
-	// parse response
 	var testPlan plan.TestPlan
-	err = json.Unmarshal(responseBody, &testPlan)
+
+	resp, err := c.DoWithRetry(ctx, httpRequest{
+		Method: http.MethodGet,
+		URL:    url,
+	}, &testPlan)
+
 	if err != nil {
-		return nil, fmt.Errorf("parsing response: %w", err)
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return nil, nil
+		}
+		return nil, err
 	}
 
 	return &testPlan, nil

--- a/internal/api/fetch_test_plan_test.go
+++ b/internal/api/fetch_test_plan_test.go
@@ -182,18 +182,12 @@ func TestFetchTestPlan_BadRequest(t *testing.T) {
 
 func TestFetchTestPlan_InternalServerError(t *testing.T) {
 	originalTimeout := retryTimeout
-	originalInitialDelay := initialDelay
-
-	retryTimeout = 500 * time.Millisecond
-	initialDelay = 1 * time.Millisecond
+	retryTimeout = 1 * time.Millisecond
 	t.Cleanup(func() {
 		retryTimeout = originalTimeout
-		initialDelay = originalInitialDelay
 	})
 
-	requestCount := 0
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestCount++
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer svr.Close()
@@ -206,10 +200,6 @@ func TestFetchTestPlan_InternalServerError(t *testing.T) {
 
 	c := NewClient(cfg)
 	got, err := c.FetchTestPlan(context.Background(), "my-suite", "xyz")
-
-	if requestCount < 2 {
-		t.Errorf("http request count = %v, want at least %d", requestCount, 2)
-	}
 
 	if !errors.Is(err, ErrRetryTimeout) {
 		t.Errorf("FetchTestPlan() error = %v, want %v", err, ErrRetryTimeout)

--- a/main.go
+++ b/main.go
@@ -58,14 +58,10 @@ func main() {
 
 	// get plan
 	ctx := context.Background()
-	// We expect the whole test plan fetching process takes no more than 60 seconds.
-	// Configure the timeout as 70s to give it a bit more buffer.
-	fetchCtx, cancel := context.WithTimeout(ctx, 70*time.Second)
-	defer cancel()
 
-	testPlan, err := fetchOrCreateTestPlan(fetchCtx, cfg, files, testRunner)
+	testPlan, err := fetchOrCreateTestPlan(ctx, cfg, files, testRunner)
 	if err != nil {
-		logErrorAndExit(16, "Couldn't create test plan: %v", err)
+		logErrorAndExit(16, "Couldn't fetch or create test plan: %v", err)
 	}
 
 	// get plan for this node
@@ -186,49 +182,67 @@ func fetchOrCreateTestPlan(ctx context.Context, cfg config.Config, files []strin
 	})
 
 	// Fetch the plan from the server's cache.
-	cachedPlan, err := apiClient.FetchTestPlan(cfg.SuiteSlug, cfg.Identifier)
+	cachedPlan, err := apiClient.FetchTestPlan(ctx, cfg.SuiteSlug, cfg.Identifier)
 
 	if err != nil {
+		// If the request hits the retry timeout, we should create a fallback plan.
+		if errors.Is(err, api.ErrRetryTimeout) {
+			fmt.Println("Could not fetch plan from server, using fallback mode. Your build may take longer than usual.")
+			testPlan := plan.CreateFallbackPlan(files, cfg.Parallelism)
+			return testPlan, nil
+		}
+		// If other errors occur, terminate the client
 		return plan.TestPlan{}, err
 	}
 
 	if cachedPlan != nil {
+		// The server can return an "error" plan indicated by an empty task list (i.e. `{"tasks": {}}`).
+		// In this case, we should create a fallback plan.
+		if len(cachedPlan.Tasks) == 0 {
+			fmt.Println("Error plan received, using fallback mode. Your build may take longer than usual.")
+			testPlan := plan.CreateFallbackPlan(files, cfg.Parallelism)
+			return testPlan, nil
+		}
+
 		debug.Printf("Test plan found. Identifier: %q", cfg.Identifier)
 		return *cachedPlan, nil
 	}
 
 	debug.Println("No test plan found, creating a new plan")
 	// If the cache is empty, create a new plan.
-	params, err := createRequestParam(cfg, files, *apiClient, testRunner)
+	params, err := createRequestParam(ctx, cfg, files, *apiClient, testRunner)
 	if err != nil {
+		// If the request hits the retry timeout, we should create a fallback plan.
+		if errors.Is(err, api.ErrRetryTimeout) {
+			fmt.Println("Could not create plan from server, using fallback mode. Your build may take longer than usual.")
+			testPlan := plan.CreateFallbackPlan(files, cfg.Parallelism)
+			return testPlan, nil
+		}
+
 		return plan.TestPlan{}, err
 	}
 
 	debug.Println("Creating test plan")
 	testPlan, err := apiClient.CreateTestPlan(ctx, cfg.SuiteSlug, params)
 
-	if err == nil {
-		debug.Printf("Test plan created. Identifier: %q", cfg.Identifier)
-	}
-
 	if err != nil {
-		// Didn't exceed context deadline? Must have been some kind of error that
-		// means we should return error to main function and abort.
-		if !errors.Is(err, context.DeadlineExceeded) {
-			return plan.TestPlan{}, err
+		// If the request hits the retry timeout, we should create a fallback plan.
+		if errors.Is(err, api.ErrRetryTimeout) {
+			fmt.Println("Could not create plan from server, using fallback mode. Your build may take longer than usual.")
+			testPlan = plan.CreateFallbackPlan(files, cfg.Parallelism)
+			return testPlan, nil
 		}
-		// Create the fallback plan
-		fmt.Println("Could not fetch plan from server, using fallback mode. Your build may take longer than usual.")
-		testPlan = plan.CreateFallbackPlan(files, cfg.Parallelism)
+		return plan.TestPlan{}, err
 	}
 
 	// The server can return an "error" plan indicated by an empty task list (i.e. `{"tasks": {}}`).
 	// In this case, we should create a fallback plan.
 	if len(testPlan.Tasks) == 0 {
-		fmt.Println("Test splitter server returned an error, using fallback mode. Your build may take longer than usual.")
+		fmt.Println("Error plan received, using fallback mode. Your build may take longer than usual.")
 		testPlan = plan.CreateFallbackPlan(files, cfg.Parallelism)
 	}
 
+	debug.Printf("Test plan created. Identifier: %q", cfg.Identifier)
 	return testPlan, nil
 }
 
@@ -243,7 +257,7 @@ type fileTiming struct {
 // If SplitByExample is enabled, it will split the slow files into examples and return it along with the rest of the files.
 //
 // Error is returned if there is a failure to fetch test file timings or to get the test examples from test files when SplitByExample is enabled.
-func createRequestParam(cfg config.Config, files []string, client api.Client, runner TestRunner) (api.TestPlanParams, error) {
+func createRequestParam(ctx context.Context, cfg config.Config, files []string, client api.Client, runner TestRunner) (api.TestPlanParams, error) {
 	if !cfg.SplitByExample {
 		debug.Println("Splitting by file")
 		testCases := []plan.TestCase{}
@@ -267,9 +281,9 @@ func createRequestParam(cfg config.Config, files []string, client api.Client, ru
 
 	debug.Printf("Fetching timings for %d files", len(files))
 	// Fetch the timings for all files.
-	timings, err := client.FetchFilesTiming(cfg.SuiteSlug, files)
+	timings, err := client.FetchFilesTiming(ctx, cfg.SuiteSlug, files)
 	if err != nil {
-		return api.TestPlanParams{}, fmt.Errorf("failed to fetch file timings: %v", err)
+		return api.TestPlanParams{}, fmt.Errorf("failed to fetch file timings: %w", err)
 	}
 	debug.Printf("Got timings for %d files", len(timings))
 
@@ -316,7 +330,7 @@ func createRequestParam(cfg config.Config, files []string, client api.Client, ru
 	// Get the examples for the slow files.
 	slowFilesExamples, err := runner.GetExamples(slowFiles)
 	if err != nil {
-		return api.TestPlanParams{}, fmt.Errorf("failed to get examples for slow files: %v", err)
+		return api.TestPlanParams{}, fmt.Errorf("failed to get examples for slow files: %w", err)
 	}
 
 	debug.Printf("Got %d examples within the slow files", len(slowFilesExamples))

--- a/main_test.go
+++ b/main_test.go
@@ -167,10 +167,6 @@ func TestFetchOrCreateTestPlan_PlanError(t *testing.T) {
 	"tasks": {}
 }`
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// simulate cache miss for GET test_plan so it will trigger the test plan creation
-		if r.Method == http.MethodGet {
-			w.WriteHeader(http.StatusNotFound)
-		}
 		fmt.Fprint(w, response)
 	}))
 	defer svr.Close()
@@ -269,7 +265,7 @@ func TestCreateRequestParams_SplitByFile(t *testing.T) {
 	}
 
 	client := api.NewClient(api.ClientConfig{})
-	got, err := createRequestParam(cfg, []string{"apple", "banana"}, *client, runner.NewRspec(""))
+	got, err := createRequestParam(context.Background(), cfg, []string{"apple", "banana"}, *client, runner.NewRspec(""))
 	want := api.TestPlanParams{
 		Identifier:  "identifier",
 		Parallelism: 7,
@@ -327,7 +323,7 @@ func TestCreateRequestParams_SplitByExample(t *testing.T) {
 		"test/spec/fruits/grape_spec.rb",
 	}
 
-	got, err := createRequestParam(cfg, files, *client, runner.NewRspec("rspec"))
+	got, err := createRequestParam(context.Background(), cfg, files, *client, runner.NewRspec("rspec"))
 
 	if err != nil {
 		t.Errorf("createRequestParam() error = %v", err)
@@ -376,7 +372,7 @@ func TestCreateRequestParams_SplitByExample(t *testing.T) {
 
 func TestCreateRequestParams_SplitByExample_NoFileTiming(t *testing.T) {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
+		w.WriteHeader(http.StatusForbidden)
 	}))
 
 	defer svr.Close()
@@ -402,7 +398,7 @@ func TestCreateRequestParams_SplitByExample_NoFileTiming(t *testing.T) {
 		"grape_spec.rb",
 	}
 
-	_, err := createRequestParam(cfg, files, *client, runner.NewRspec(""))
+	_, err := createRequestParam(context.Background(), cfg, files, *client, runner.NewRspec(""))
 
 	if err == nil {
 		t.Errorf("createRequestParam() want error, got nil")
@@ -444,7 +440,7 @@ func TestCreateRequestParams_SplitByExample_MissingSomeOfTiming(t *testing.T) {
 		"test/spec/fruits/grape_spec.rb",
 	}
 
-	got, err := createRequestParam(cfg, files, *client, runner.NewRspec("rspec"))
+	got, err := createRequestParam(context.Background(), cfg, files, *client, runner.NewRspec("rspec"))
 
 	if err != nil {
 		t.Errorf("createRequestParam() error = %v", err)
@@ -521,7 +517,7 @@ func TestCreateRequestParams_SplitByExample_NoSlowFiles(t *testing.T) {
 		"test/spec/fruits/grape_spec.rb",
 	}
 
-	got, err := createRequestParam(cfg, files, *client, runner.NewRspec("rspec"))
+	got, err := createRequestParam(context.Background(), cfg, files, *client, runner.NewRspec("rspec"))
 
 	if err != nil {
 		t.Errorf("createRequestParam() error = %v", err)


### PR DESCRIPTION
We need to improve the robustness of error handling when communicating to the server to fetch or create the test plan. The error handling below applied to all requests made by the client, including fetch test plan, create test plan, and fetch files timing.

- Request errors (redirection error, protocol error, time-out) should be retried using exponential back-off, and fall back to naive test plan after reaching retry time-out.
- 5xx responses should be retried using exponential back-off.
- 429 responses should be retried after rate limit reset. 
- 4xx responses should terminate the client.
- Reading and parsing response errors should terminate the client.

For no 1, 2, 3 the requests should be retried in a loop until it reaches 130 seconds, and fall back to native plan if it's still not successful.

### Implementation
This PR creates a new function called `DoWithRetry` within the `api.Client` struct. The function takes a `ctx context.Context`, `req api.httpRequest` that includes request method, URL, and body, and `v interface{}` which is a pointer to store the response in case of successful request. This function also encodes the request body, creates the http request, and decodes the response body.

`FetchTestPlan`, `CreateTestPlan`, and `FetchFilesTiming` functions were refactored to call `DoWithRetry` function instead of calling `http.Client.Do` directly.

the `main` function is refactored to handle the error cases described above.