### PR TITLE
Add pact interaction for create test plan with split by example disabled

### DIFF
--- a/internal/api/create_test_plan.go
+++ b/internal/api/create_test_plan.go
@@ -20,7 +20,7 @@ var (
 
 type TestPlanParamsTest struct {
 	Files    []plan.TestCase `json:"files"`
-	Examples []plan.TestCase `json:"examples"`
+	Examples []plan.TestCase `json:"examples,omitempty"`
 }
 
 // TestPlanParams represents the config params sent when fetching a test plan.

--- a/internal/api/create_test_plan_test.go
+++ b/internal/api/create_test_plan_test.go
@@ -32,6 +32,108 @@ func TestCreateTestPlan(t *testing.T) {
 			Files: []plan.TestCase{
 				{Path: "sky_spec.rb"},
 			},
+		},
+	}
+
+	err = mockProvider.
+		AddInteraction().
+		Given("A test plan doesn't exist").
+		UponReceiving("A request to create test plan with identifier abc123").
+		WithRequest("POST", "/v2/analytics/organizations/buildkite/suites/rspec/test_plan", func(b *consumer.V2RequestBuilder) {
+			b.Header("Authorization", matchers.String("Bearer asdf1234"))
+			b.Header("Content-Type", matchers.String("application/json"))
+			b.JSONBody(params)
+		}).
+		WillRespondWith(200, func(b *consumer.V2ResponseBuilder) {
+			b.Header("Content-Type", matchers.String("application/json; charset=utf-8"))
+			b.JSONBody(matchers.MapMatcher{
+				"tasks": matchers.Like(map[string]interface{}{
+					"0": matchers.Like(map[string]interface{}{
+						"node_number": matchers.Like(0),
+						"tests": matchers.EachLike(matchers.MapMatcher{
+							"path":               matchers.Like("sky_spec.rb"),
+							"format":             matchers.Like("file"),
+							"estimated_duration": matchers.Like(1000),
+						}, 1),
+					}),
+					"1": matchers.Like(map[string]interface{}{
+						"node_number": matchers.Like(1),
+						"tests":       []plan.TestCase{},
+					}),
+					"2": matchers.Like(map[string]interface{}{
+						"node_number": matchers.Like(2),
+						"tests":       []plan.TestCase{},
+					}),
+				}),
+			})
+		}).
+		ExecuteTest(t, func(config consumer.MockServerConfig) error {
+			ctx := context.Background()
+			fetchCtx, cancel := context.WithTimeout(ctx, 1*time.Second)
+			defer cancel()
+
+			url := fmt.Sprintf("http://%s:%d", config.Host, config.Port)
+			apiClient := NewClient(ClientConfig{
+				AccessToken:      "asdf1234",
+				OrganizationSlug: "buildkite",
+				ServerBaseUrl:    url,
+			})
+
+			got, err := apiClient.CreateTestPlan(fetchCtx, "rspec", params)
+			if err != nil {
+				t.Errorf("CreateTestPlan(ctx, %v) error = %v", params, err)
+			}
+
+			want := plan.TestPlan{
+				Tasks: map[string]*plan.Task{
+					"0": {
+						NodeNumber: 0,
+						Tests: []plan.TestCase{{
+							Path:              "sky_spec.rb",
+							Format:            "file",
+							EstimatedDuration: 1000,
+						}},
+					},
+					"1": {
+						NodeNumber: 1,
+						Tests:      []plan.TestCase{},
+					},
+					"2": {
+						NodeNumber: 2,
+						Tests:      []plan.TestCase{},
+					},
+				},
+			}
+
+			if diff := cmp.Diff(got, want); diff != "" {
+				t.Errorf("CreateTestPlan(ctx, %v) diff (-got +want):\n%s", params, diff)
+			}
+
+			return nil
+		})
+
+	if err != nil {
+		t.Error("mockProvider error", err)
+	}
+}
+
+func TestCreateTestPlan_SplitByExample(t *testing.T) {
+	mockProvider, err := consumer.NewV2Pact(consumer.MockHTTPProviderConfig{
+		Consumer: "TestSplitterClient",
+		Provider: "TestSplitterServer",
+	})
+
+	if err != nil {
+		t.Error("Error mocking provider", err)
+	}
+
+	params := TestPlanParams{
+		Identifier:  "abc123",
+		Parallelism: 3,
+		Tests: TestPlanParamsTest{
+			Files: []plan.TestCase{
+				{Path: "sky_spec.rb"},
+			},
 			Examples: []plan.TestCase{
 				{
 					Path:       "sea_spec.rb:4",
@@ -46,7 +148,7 @@ func TestCreateTestPlan(t *testing.T) {
 	err = mockProvider.
 		AddInteraction().
 		Given("A test plan doesn't exist").
-		UponReceiving("A request to create test plan with identifier abc123").
+		UponReceiving("A request to create test plan with identifier abc123 and split by example enabled").
 		WithRequest("POST", "/v2/analytics/organizations/buildkite/suites/rspec/test_plan", func(b *consumer.V2RequestBuilder) {
 			b.Header("Authorization", matchers.String("Bearer asdf1234"))
 			b.Header("Content-Type", matchers.String("application/json"))

--- a/internal/api/create_test_plan_test.go
+++ b/internal/api/create_test_plan_test.go
@@ -38,7 +38,7 @@ func TestCreateTestPlan(t *testing.T) {
 	err = mockProvider.
 		AddInteraction().
 		Given("A test plan doesn't exist").
-		UponReceiving("A request to create test plan with identifier abc123").
+		UponReceiving("A request to create test plan with identifier abc123 and split by example disabled").
 		WithRequest("POST", "/v2/analytics/organizations/buildkite/suites/rspec/test_plan", func(b *consumer.V2RequestBuilder) {
 			b.Header("Authorization", matchers.String("Bearer asdf1234"))
 			b.Header("Content-Type", matchers.String("application/json"))


### PR DESCRIPTION
Create test plan has 2 different scenarios, when split by example is enabled and disabled.
We need to add pact interactions to test that both scenarios are met by the API.