### PR TITLE
Ignore request body when it is empty or when the request is a GET request

### DIFF
--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -120,7 +120,11 @@ func TestDoWithRetry_Succesful_GET(t *testing.T) {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 
-		bodyBytes, _ := io.ReadAll(r.Body)
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Error(err)
+		}
+
 		if len(bodyBytes) > 0 {
 			t.Errorf("request body = %q, want empty", string(bodyBytes))
 		}


### PR DESCRIPTION
Test splitter client unexpectedly sends `null` as request body when making a `GET` request to the API, which get blocked by Cloudfront. We need to make sure that empty body is not accidentally send as `null` string, and make sure that `GET` request doesn't have a request body.

Request
```
GET /v2/analytics/organizations/buildkite/suites/buildkite/test_plan?identifier=xxx HTTP/1.1
Host: api.buildkite.com
User-Agent: Go-http-client/1.1
Content-Length: 4
Content-Type: application/json
Accept-Encoding: gzip

null
```
Response:
```
!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
<HTML><HEAD><META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=iso-8859-1">
<TITLE>ERROR: The request could not be satisfied</TITLE>
</HEAD><BODY>
<H1>403 ERROR</H1>
<H2>The request could not be satisfied.</H2>
<HR noshade size="1px">
Bad request.
We can't connect to the server for this app or website at this time. There might be too much traffic or a configuration error. Try again later, or contact the app or website owner.
<BR clear="all">
If you provide content to customers through CloudFront, you can find steps to troubleshoot and help prevent this error by reviewing the CloudFront documentation.
<BR clear="all">
<HR noshade size="1px">
<PRE>
Generated by cloudfront (CloudFront)
Request ID: xxx
</PRE>
<ADDRESS>
</ADDRESS>
</BODY></HTML>
```

Documentation around behavior for GET request with body in Cloudfront:
https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/RequestAndResponseBehaviorCustomOrigin.html#RequestCustom-get-body

### Verification
I have tested this against production API, and verified that it is working
```
2024/06/21 13:31:23 DEBUG: Fetching test plan
2024/06/21 13:31:23 DEBUG: Sending request GET https://api.buildkite.com/v2/analytics/organizations/buildkite/suites/buildkite-rspec/test_plan?identifier=1718933483
2024/06/21 13:31:24 DEBUG: Response code 404
2024/06/21 13:31:24 DEBUG: No test plan found, creating a new plan
2024/06/21 13:31:24 DEBUG: Splitting by example
2024/06/21 13:31:24 DEBUG: Fetching timings for 2033 files
2024/06/21 13:31:24 DEBUG: Sending request POST https://api.buildkite.com/v2/analytics/organizations/buildkite/suites/buildkite-rspec/test_files
2024/06/21 13:31:26 DEBUG: Response code 200
2024/06/21 13:31:26 DEBUG: Got timings for 2029 files
2024/06/21 13:31:26 DEBUG: Getting examples for 2 slow files
2024/06/21 13:31:26 DEBUG: Running `rspec --dry-run`
2024/06/21 13:31:35 DEBUG: Got 105 examples within the slow files
2024/06/21 13:31:35 DEBUG: Creating test plan
2024/06/21 13:31:35 DEBUG: Sending request POST https://api.buildkite.com/v2/analytics/organizations/buildkite/suites/buildkite-rspec/test_plan
2024/06/21 13:31:37 DEBUG: Response code 200
2024/06/21 13:31:38 DEBUG: Test plan created. Identifier: "1718933483"
```