### PR TITLE
Record Rspec executions and send metadata to Test Analytics

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -164,9 +164,11 @@ func (c *Client) DoWithRetry(ctx context.Context, req httpRequest, v interface{}
 		}
 
 		// parse response
-		err = json.Unmarshal(responseBody, v)
-		if err != nil {
-			return nil, fmt.Errorf("parsing response: %w", err)
+		if v != nil {
+			err = json.Unmarshal(responseBody, v)
+			if err != nil {
+				return nil, fmt.Errorf("parsing response: %w", err)
+			}
 		}
 
 		return resp, nil

--- a/internal/api/post_test_plan_metadata.go
+++ b/internal/api/post_test_plan_metadata.go
@@ -1,0 +1,30 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+type Timeline struct {
+	Timestamp string `json:"timestamp"`
+	Event     string `json:"event"`
+}
+
+type TestPlanMetadataParams struct {
+	Version     string                 `json:"version"`
+	SplitterEnv map[string]interface{} `json:"splitter_env"`
+	Timeline    []Timeline             `json:"timeline"`
+}
+
+func (c Client) PostTestPlanMetadata(ctx context.Context, suiteSlug string, identifier string, params TestPlanMetadataParams) error {
+	url := fmt.Sprintf("%s/v2/analytics/organizations/%s/suites/%s/test_plan_metadata", c.ServerBaseUrl, c.OrganizationSlug, suiteSlug)
+
+	_, err := c.DoWithRetry(ctx, httpRequest{
+		Method: http.MethodPost,
+		URL:    url,
+		Body:   params,
+	}, nil)
+
+	return err
+}

--- a/internal/api/post_test_plan_metadata.go
+++ b/internal/api/post_test_plan_metadata.go
@@ -12,9 +12,9 @@ type Timeline struct {
 }
 
 type TestPlanMetadataParams struct {
-	Version     string                 `json:"version"`
-	SplitterEnv map[string]interface{} `json:"splitter_env"`
-	Timeline    []Timeline             `json:"timeline"`
+	Version     string            `json:"version"`
+	SplitterEnv map[string]string `json:"splitter_env"`
+	Timeline    []Timeline        `json:"timeline"`
 }
 
 func (c Client) PostTestPlanMetadata(ctx context.Context, suiteSlug string, identifier string, params TestPlanMetadataParams) error {

--- a/internal/api/post_test_plan_metadata_test.go
+++ b/internal/api/post_test_plan_metadata_test.go
@@ -1,0 +1,156 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/pact-foundation/pact-go/v2/consumer"
+	"github.com/pact-foundation/pact-go/v2/matchers"
+)
+
+func TestPostTestPlanMetadata(t *testing.T) {
+	mockProvider, err := consumer.NewV2Pact(consumer.MockHTTPProviderConfig{
+		Consumer: "TestSplitterClient",
+		Provider: "TestSplitterServer",
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	params := TestPlanMetadataParams{
+		Version: "0.7.0",
+		SplitterEnv: map[string]interface{}{
+			"BUILDKITE_PARALLEL_JOB_COUNT":            3,
+			"BUILDKITE_PARALLEL_JOB":                  1,
+			"BUILDKITE_SPLITTER_SUITE_SLUG":           "my_slug",
+			"BUILDKITE_SPLITTER_TEST_EXCLUDE_PATTERN": nil,
+			"BUILDKITE_SPLITTER_SPLIT_BY_EXAMPLE":     false,
+			"BUILDKITE_SPLITTER_IDENTIFIER":           "abc123",
+		},
+		Timeline: []Timeline{
+			{
+				Event:     "test_start",
+				Timestamp: "2024-06-20T04:46:13.60977Z",
+			},
+			{
+				Event:     "test_end",
+				Timestamp: "2024-06-20T04:49:09.609793Z",
+			},
+		},
+	}
+
+	err = mockProvider.
+		AddInteraction().
+		Given("A test plan exists").
+		UponReceiving("A request to post test plan metadata with identifier abc123").
+		WithRequest("POST", "/v2/analytics/organizations/buildkite/suites/rspec/test_plan_metadata", func(b *consumer.V2RequestBuilder) {
+			b.Header("Authorization", matchers.String("Bearer asdf1234"))
+			b.Header("Content-Type", matchers.String("application/json"))
+			b.JSONBody(params)
+		}).
+		WillRespondWith(200, func(b *consumer.V2ResponseBuilder) {
+			b.Header("Content-Type", matchers.Like("application/json; charset=utf-8"))
+			b.JSONBody(matchers.MapMatcher{
+				"head": matchers.String("no_content"),
+			})
+		}).
+		ExecuteTest(t, func(config consumer.MockServerConfig) error {
+			url := fmt.Sprintf("http://%s:%d", config.Host, config.Port)
+			c := NewClient(ClientConfig{
+				AccessToken:      "asdf1234",
+				OrganizationSlug: "buildkite",
+				ServerBaseUrl:    url,
+			})
+
+			_, err := c.DoWithRetry(context.Background(), httpRequest{
+				Method: "POST",
+				URL:    fmt.Sprintf("%s/v2/analytics/organizations/%s/suites/%s/test_plan_metadata", c.ServerBaseUrl, c.OrganizationSlug, "rspec"),
+				Body:   params,
+			}, nil)
+
+			if err != nil {
+				t.Errorf("PostTestPlanMetadata() error = %v", err)
+			}
+
+			return nil
+		})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPostTestPlanMetadata_NotFound(t *testing.T) {
+	mockProvider, err := consumer.NewV2Pact(consumer.MockHTTPProviderConfig{
+		Consumer: "TestSplitterClient",
+		Provider: "TestSplitterServer",
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	params := TestPlanMetadataParams{
+		Version: "0.7.0",
+		SplitterEnv: map[string]interface{}{
+			"BUILDKITE_PARALLEL_JOB_COUNT":            3,
+			"BUILDKITE_PARALLEL_JOB":                  1,
+			"BUILDKITE_SPLITTER_SUITE_SLUG":           "my_slug",
+			"BUILDKITE_SPLITTER_TEST_EXCLUDE_PATTERN": nil,
+			"BUILDKITE_SPLITTER_SPLIT_BY_EXAMPLE":     false,
+			"BUILDKITE_SPLITTER_IDENTIFIER":           "abc123",
+		},
+		Timeline: []Timeline{
+			{
+				Event:     "test_start",
+				Timestamp: "2024-06-20T04:46:13.60977Z",
+			},
+			{
+				Event:     "test_end",
+				Timestamp: "2024-06-20T04:49:09.609793Z",
+			},
+		},
+	}
+
+	err = mockProvider.
+		AddInteraction().
+		Given("A test plan doesn't exist").
+		UponReceiving("A request to post test plan metadata with identifier abc123").
+		WithRequest("POST", "/v2/analytics/organizations/buildkite/suites/rspec/test_plan_metadata", func(b *consumer.V2RequestBuilder) {
+			b.Header("Authorization", matchers.String("Bearer asdf1234"))
+			b.Header("Content-Type", matchers.String("application/json"))
+			b.JSONBody(params)
+		}).
+		WillRespondWith(404, func(b *consumer.V2ResponseBuilder) {
+			b.Header("Content-Type", matchers.Like("application/json; charset=utf-8"))
+			b.JSONBody(matchers.MapMatcher{
+				"message": matchers.Like("Test plan not found"),
+			})
+		}).
+		ExecuteTest(t, func(config consumer.MockServerConfig) error {
+			url := fmt.Sprintf("http://%s:%d", config.Host, config.Port)
+			c := NewClient(ClientConfig{
+				AccessToken:      "asdf1234",
+				OrganizationSlug: "buildkite",
+				ServerBaseUrl:    url,
+			})
+
+			_, err := c.DoWithRetry(context.Background(), httpRequest{
+				Method: "POST",
+				URL:    fmt.Sprintf("%s/v2/analytics/organizations/%s/suites/%s/test_plan_metadata", c.ServerBaseUrl, c.OrganizationSlug, "rspec"),
+				Body:   params,
+			}, nil)
+
+			if err == nil {
+				t.Errorf("PostTestPlanMetadata() error = %v, want %v", err, "Test plan not found")
+			}
+
+			return nil
+		})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/api/post_test_plan_metadata_test.go
+++ b/internal/api/post_test_plan_metadata_test.go
@@ -21,12 +21,12 @@ func TestPostTestPlanMetadata(t *testing.T) {
 
 	params := TestPlanMetadataParams{
 		Version: "0.7.0",
-		SplitterEnv: map[string]interface{}{
-			"BUILDKITE_PARALLEL_JOB_COUNT":            3,
-			"BUILDKITE_PARALLEL_JOB":                  1,
+		SplitterEnv: map[string]string{
+			"BUILDKITE_PARALLEL_JOB_COUNT":            "3",
+			"BUILDKITE_PARALLEL_JOB":                  "1",
 			"BUILDKITE_SPLITTER_SUITE_SLUG":           "my_slug",
-			"BUILDKITE_SPLITTER_TEST_EXCLUDE_PATTERN": nil,
-			"BUILDKITE_SPLITTER_SPLIT_BY_EXAMPLE":     false,
+			"BUILDKITE_SPLITTER_TEST_EXCLUDE_PATTERN": "",
+			"BUILDKITE_SPLITTER_SPLIT_BY_EXAMPLE":     "false",
 			"BUILDKITE_SPLITTER_IDENTIFIER":           "abc123",
 		},
 		Timeline: []Timeline{
@@ -94,12 +94,12 @@ func TestPostTestPlanMetadata_NotFound(t *testing.T) {
 
 	params := TestPlanMetadataParams{
 		Version: "0.7.0",
-		SplitterEnv: map[string]interface{}{
-			"BUILDKITE_PARALLEL_JOB_COUNT":            3,
-			"BUILDKITE_PARALLEL_JOB":                  1,
+		SplitterEnv: map[string]string{
+			"BUILDKITE_PARALLEL_JOB_COUNT":            "3",
+			"BUILDKITE_PARALLEL_JOB":                  "1",
 			"BUILDKITE_SPLITTER_SUITE_SLUG":           "my_slug",
-			"BUILDKITE_SPLITTER_TEST_EXCLUDE_PATTERN": nil,
-			"BUILDKITE_SPLITTER_SPLIT_BY_EXAMPLE":     false,
+			"BUILDKITE_SPLITTER_TEST_EXCLUDE_PATTERN": "",
+			"BUILDKITE_SPLITTER_SPLIT_BY_EXAMPLE":     "false",
 			"BUILDKITE_SPLITTER_IDENTIFIER":           "abc123",
 		},
 		Timeline: []Timeline{

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -33,3 +33,33 @@ func getIntEnvWithDefault(key string, defaultValue int) (int, error) {
 	// Return the value if it's successfully converted to int.
 	return valueInt, nil
 }
+
+func (c Config) DumpEnv() map[string]string {
+	keys := []string{
+		"BUILDKITE_BUILD_ID",
+		"BUILDKITE_JOB_ID",
+		"BUILDKITE_ORGANIZATION_SLUG",
+		"BUILDKITE_PARALLEL_JOB_COUNT",
+		"BUILDKITE_PARALLEL_JOB",
+		"BUILDKITE_SPLITTER_DEBUG_ENABLED",
+		"BUILDKITE_SPLITTER_IDENTIFIER",
+		"BUILDKITE_SPLITTER_RETRY_COUNT",
+		"BUILDKITE_SPLITTER_SLOW_FILE_THRESHOLD",
+		"BUILDKITE_SPLITTER_SPLIT_BY_EXAMPLE",
+		"BUILDKITE_SPLITTER_SUITE_SLUG",
+		"BUILDKITE_SPLITTER_TEST_CMD",
+		"BUILDKITE_SPLITTER_TEST_FILE_EXCLUDE_PATTERN",
+		"BUILDKITE_SPLITTER_TEST_FILE_PATTERN",
+	}
+
+	envs := make(map[string]string)
+	for _, key := range keys {
+		envs[key] = os.Getenv(key)
+	}
+
+	if envs["BUILDKITE_SPLITTER_IDENTIFIER"] == "" {
+		envs["BUILDKITE_SPLITTER_IDENTIFIER"] = c.Identifier
+	}
+
+	return envs
+}

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -50,6 +50,7 @@ func (c Config) DumpEnv() map[string]string {
 		"BUILDKITE_SPLITTER_TEST_CMD",
 		"BUILDKITE_SPLITTER_TEST_FILE_EXCLUDE_PATTERN",
 		"BUILDKITE_SPLITTER_TEST_FILE_PATTERN",
+		"BUILDKITE_STEP_ID",
 	}
 
 	envs := make(map[string]string)

--- a/main.go
+++ b/main.go
@@ -162,6 +162,7 @@ func sendMetadata(ctx context.Context, apiClient *api.Client, cfg config.Config,
 		Version:     Version,
 	})
 
+	// Error is suppressed because we don't want to fail the build if we can't send metadata.
 	if err != nil {
 		fmt.Printf("Failed to send metadata: %v\n", err)
 	}

--- a/main.go
+++ b/main.go
@@ -84,14 +84,14 @@ func main() {
 		logErrorAndExit(16, "Couldn't process test command: %q, %v", testRunner.TestCommand, err)
 	}
 
+	if err := cmd.Start(); err != nil {
+		logErrorAndExit(16, "Couldn't start tests: %v", err)
+	}
 	var timeline []api.Timeline
 	timeline = append(timeline, api.Timeline{
 		Event:     "test_start",
 		Timestamp: createTimestamp(),
 	})
-	if err := cmd.Start(); err != nil {
-		logErrorAndExit(16, "Couldn't start tests: %v", err)
-	}
 
 	// Create a channel that will be closed when the command finishes.
 	finishCh := make(chan struct{})
@@ -164,7 +164,7 @@ func sendMetadata(ctx context.Context, apiClient *api.Client, cfg config.Config,
 
 	// Error is suppressed because we don't want to fail the build if we can't send metadata.
 	if err != nil {
-		fmt.Printf("Failed to send metadata: %v\n", err)
+		fmt.Printf("Failed to send metadata to Test Analytics: %v\n", err)
 	}
 }
 
@@ -180,13 +180,13 @@ func retryFailedTests(testRunner TestRunner, maxRetries int, timeline *[]api.Tim
 			logErrorAndExit(16, "Couldn't process retry command: %v", err)
 		}
 
+		if err := cmd.Start(); err != nil {
+			logErrorAndExit(16, "Couldn't start tests: %v", err)
+		}
 		*timeline = append(*timeline, api.Timeline{
 			Event:     fmt.Sprintf("retry_%d_start", retries),
 			Timestamp: createTimestamp(),
 		})
-		if err := cmd.Start(); err != nil {
-			logErrorAndExit(16, "Couldn't start tests: %v", err)
-		}
 
 		err = cmd.Wait()
 		*timeline = append(*timeline, api.Timeline{

--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ func main() {
 		ServerBaseUrl:    cfg.ServerBaseUrl,
 		AccessToken:      cfg.AccessToken,
 		OrganizationSlug: cfg.OrganizationSlug,
-		Version:          cfg.Version,
+		Version:          Version,
 	})
 
 	testPlan, err := fetchOrCreateTestPlan(ctx, apiClient, cfg, files, testRunner)

--- a/main.go
+++ b/main.go
@@ -129,16 +129,14 @@ func main() {
 				logErrorAndExit(exitCode, "Rspec exited with error %v", err)
 			} else {
 				retryExitCode := retryFailedTests(testRunner, cfg.MaxRetries, &timeline)
-				if retryExitCode == 0 {
-					sendMetadata(cfg, timeline)
-					os.Exit(0)
-				} else {
+				if retryExitCode != 0 {
 					sendMetadata(cfg, timeline)
 					logErrorAndExit(retryExitCode, "Rspec exited with error %v after retry failing tests", err)
 				}
 			}
+		} else {
+			logErrorAndExit(16, "Couldn't run tests: %v", err)
 		}
-		logErrorAndExit(16, "Couldn't run tests: %v", err)
 	}
 
 	sendMetadata(cfg, timeline)

--- a/main_test.go
+++ b/main_test.go
@@ -80,6 +80,9 @@ func TestFetchOrCreateTestPlan(t *testing.T) {
 		Identifier:    "identifier",
 		ServerBaseUrl: svr.URL,
 	}
+	apiClient := api.NewClient(api.ClientConfig{
+		ServerBaseUrl: cfg.ServerBaseUrl,
+	})
 
 	// we want the function to return the test plan fetched from the server
 	want := plan.TestPlan{
@@ -91,7 +94,7 @@ func TestFetchOrCreateTestPlan(t *testing.T) {
 		},
 	}
 
-	got, err := fetchOrCreateTestPlan(ctx, cfg, files, testRunner)
+	got, err := fetchOrCreateTestPlan(ctx, apiClient, cfg, files, testRunner)
 	if err != nil {
 		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) error = %v", cfg, files, err)
 	}
@@ -146,6 +149,10 @@ func TestFetchOrCreateTestPlan_CachedPlan(t *testing.T) {
 		OrganizationSlug: "org",
 		SuiteSlug:        "suite",
 	}
+	apiClient := api.NewClient(api.ClientConfig{
+		ServerBaseUrl:    cfg.ServerBaseUrl,
+		OrganizationSlug: cfg.OrganizationSlug,
+	})
 
 	tests := []string{"banana"}
 	testRunner := runner.NewRspec("")
@@ -159,7 +166,7 @@ func TestFetchOrCreateTestPlan_CachedPlan(t *testing.T) {
 		},
 	}
 
-	got, err := fetchOrCreateTestPlan(context.Background(), cfg, tests, testRunner)
+	got, err := fetchOrCreateTestPlan(context.Background(), apiClient, cfg, tests, testRunner)
 	if err != nil {
 		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) error = %v", cfg, tests, err)
 	}
@@ -188,11 +195,14 @@ func TestFetchOrCreateTestPlan_PlanError(t *testing.T) {
 		Identifier:    "identifier",
 		ServerBaseUrl: svr.URL,
 	}
+	apiClient := api.NewClient(api.ClientConfig{
+		ServerBaseUrl: cfg.ServerBaseUrl,
+	})
 
 	// we want the function to return a fallback plan
 	want := plan.CreateFallbackPlan(files, cfg.Parallelism)
 
-	got, err := fetchOrCreateTestPlan(ctx, cfg, files, TestRunner)
+	got, err := fetchOrCreateTestPlan(ctx, apiClient, cfg, files, TestRunner)
 	if err != nil {
 		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) error = %v", cfg, files, err)
 	}
@@ -222,11 +232,14 @@ func TestFetchOrCreateTestPlan_InternalServerError(t *testing.T) {
 		Identifier:    "identifier",
 		ServerBaseUrl: svr.URL,
 	}
+	apiClient := api.NewClient(api.ClientConfig{
+		ServerBaseUrl: cfg.ServerBaseUrl,
+	})
 
 	// we want the function to return a fallback plan
 	want := plan.CreateFallbackPlan(files, cfg.Parallelism)
 
-	got, err := fetchOrCreateTestPlan(fetchCtx, cfg, files, testRunner)
+	got, err := fetchOrCreateTestPlan(fetchCtx, apiClient, cfg, files, testRunner)
 	if err != nil {
 		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) error = %v", cfg, files, err)
 	}
@@ -253,11 +266,14 @@ func TestFetchOrCreateTestPlan_BadRequest(t *testing.T) {
 		Identifier:    "identifier",
 		ServerBaseUrl: svr.URL,
 	}
+	apiClient := api.NewClient(api.ClientConfig{
+		ServerBaseUrl: cfg.ServerBaseUrl,
+	})
 
 	// we want the function to return an empty test plan and an error
 	want := plan.TestPlan{}
 
-	got, err := fetchOrCreateTestPlan(ctx, cfg, files, testRunner)
+	got, err := fetchOrCreateTestPlan(ctx, apiClient, cfg, files, testRunner)
 	if err == nil {
 		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) want error, got %v", cfg, files, err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -18,20 +18,30 @@ import (
 func TestRetryFailedTests(t *testing.T) {
 	testRunner := runner.NewRspec("true")
 	maxRetries := 3
-	exitCode := retryFailedTests(testRunner, maxRetries)
+	timeline := []api.Timeline{}
+	exitCode := retryFailedTests(testRunner, maxRetries, &timeline)
 	want := 0
 	if exitCode != want {
 		t.Errorf("retryFailedTests(%v, %v) = %v, want %v", testRunner, maxRetries, exitCode, want)
+	}
+
+	if len(timeline) != 2 {
+		t.Errorf("retryFailedTests(%v, %v) timeline length = %v, want %d", testRunner, maxRetries, len(timeline), 2)
 	}
 }
 
 func TestRetryFailedTests_Failure(t *testing.T) {
 	testRunner := runner.NewRspec("false")
 	maxRetries := 3
-	exitCode := retryFailedTests(testRunner, maxRetries)
+	timeline := []api.Timeline{}
+	exitCode := retryFailedTests(testRunner, maxRetries, &timeline)
 	want := 1
 	if exitCode != want {
 		t.Errorf("retryFailedTests(%v, %v) = %v, want %v", testRunner, maxRetries, exitCode, want)
+	}
+
+	if len(timeline) != 6 {
+		t.Errorf("retryFailedTests(%v, %v) timeline length = %v, want %d", testRunner, maxRetries, len(timeline), 6)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -588,6 +588,7 @@ func TestSendMetadata(t *testing.T) {
 	env := map[string]string{
 		"BUILDKITE_BUILD_ID":               "xyz",
 		"BUILDKITE_JOB_ID":                 "abc",
+		"BUILDKITE_STEP_ID":                "pqr",
 		"BUILDKITE_ORGANIZATION_SLUG":      "buildkite",
 		"BUILDKITE_PARALLEL_JOB_COUNT":     "10",
 		"BUILDKITE_PARALLEL_JOB":           "5",
@@ -629,6 +630,7 @@ func TestSendMetadata(t *testing.T) {
 				"BUILDKITE_SPLITTER_RETRY_COUNT": "2",
 				"BUILDKITE_SPLITTER_SUITE_SLUG":  "rspec",
 				"BUILDKITE_SPLITTER_TEST_CMD":    "bundle exec rspec",
+				"BUILDKITE_STEP_ID":              "pqr",
 				// ensure that empty env vars is included in the request
 				"BUILDKITE_SPLITTER_SLOW_FILE_THRESHOLD":       "",
 				"BUILDKITE_SPLITTER_SPLIT_BY_EXAMPLE":          "",


### PR DESCRIPTION
### Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->
We are building a UI in Test Analytics to display the test splitting span for each parallel job. To do this, we need the data of each rspec execution's start and finish, including the retry. This PR records each rspec execution's start/finish and send them along with env variables and version to Test Analytics.

The error raised when sending the metadata is suppressed, to prevent the build from failing.
