### PR TITLE
Pass the correct version to api.Client

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,8 +28,6 @@ type Config struct {
 	SuiteSlug string
 	// TestCommand is the command to run the tests.
 	TestCommand string
-	// Version is the current splitter version
-	Version string
 }
 
 // New wraps the readFromEnv and validate functions to create a new Config struct.

--- a/main.go
+++ b/main.go
@@ -178,7 +178,7 @@ func fetchOrCreateTestPlan(ctx context.Context, cfg config.Config, files []strin
 		ServerBaseUrl:    cfg.ServerBaseUrl,
 		AccessToken:      cfg.AccessToken,
 		OrganizationSlug: cfg.OrganizationSlug,
-		Version:          cfg.Version,
+		Version:          Version,
 	})
 
 	// Fetch the plan from the server's cache.


### PR DESCRIPTION
### Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->
The client version is still missing in the user agent after `0.6.0`. This PR fixes the issue by passing the correct version to the `api.Client`
