### PR TITLE
Improve logging to show its coming from TSC 

### DIFF
--- a/main.go
+++ b/main.go
@@ -78,6 +78,7 @@ func main() {
 		runnableTests = append(runnableTests, testCase.Path)
 	}
 
+	fmt.Printf("+++ Buildkite Test Splitter: Running tests")
 	cmd, err := testRunner.Command(runnableTests)
 	if err != nil {
 		logErrorAndExit(16, "Couldn't process test command: %q, %v", testRunner.TestCommand, err)

--- a/main.go
+++ b/main.go
@@ -172,7 +172,8 @@ func retryFailedTests(testRunner TestRunner, maxRetries int, timeline *[]api.Tim
 	retries := 0
 	for retries < maxRetries {
 		retries++
-		fmt.Printf("Attempt %d of %d to retry failing tests\n", retries, maxRetries)
+
+		fmt.Printf("+++ Buildkite Test Splitter: ♻️ Attempt %d of %d to retry failing tests\n", retries, maxRetries)
 
 		cmd, err := testRunner.RetryCommand()
 		if err != nil {
@@ -210,7 +211,7 @@ func retryFailedTests(testRunner TestRunner, maxRetries int, timeline *[]api.Tim
 
 // logErrorAndExit logs an error message and exits with the given exit code.
 func logErrorAndExit(exitCode int, format string, v ...any) {
-	fmt.Printf(format+"\n", v...)
+	fmt.Printf("Buildkite Test Splitter: "+format+"\n", v...)
 	os.Exit(exitCode)
 }
 


### PR DESCRIPTION
### Description

Added the prefix "Buildkite Test Collector" before all error exit messages, and before retries to test failures. Have set retries to always be expanded because we don't support any CI other than Buildkite atm  🤷‍♀️ 

### Context

https://buildkite-corp.slack.com/archives/C05NAGJREJU/p1719808219253619

