### PR TITLE
Fix missing newline in logging.

### DIFF
--- a/main.go
+++ b/main.go
@@ -78,7 +78,7 @@ func main() {
 		runnableTests = append(runnableTests, testCase.Path)
 	}
 
-	fmt.Printf("+++ Buildkite Test Splitter: Running tests")
+	fmt.Printf("+++ Buildkite Test Splitter: Running tests\n")
 	cmd, err := testRunner.Command(runnableTests)
 	if err != nil {
 		logErrorAndExit(16, "Couldn't process test command: %q, %v", testRunner.TestCommand, err)


### PR DESCRIPTION
### Description

#108 improved the logging functionality by adding a prefix 'Buildkite Test Splitter' to certain parts of the logging. One of these places is missing a newline.

### Context

https://linear.app/buildkite/issue/TAT-231/improve-logging-of-retries

### Changes

Add newline.

### Testing

Upgrade test splitter client after release
