### PR TITLE
Expose dry-run output to stdout

### DIFF
--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -6,19 +6,19 @@ import (
 	"os"
 )
 
-var enabled = false
+var Enabled = false
 var logger = log.New(os.Stdout, "DEBUG: ", log.LstdFlags|log.Lmsgprefix)
 
 // Printf works like log.Printf, but only when debugging is enabled.
 func Printf(format string, v ...interface{}) {
-	if enabled {
+	if Enabled {
 		logger.Printf(format, v...)
 	}
 }
 
 // Println works like log.Println, but only when debugging is enabled.
 func Println(v ...interface{}) {
-	if enabled {
+	if Enabled {
 		logger.Println(v...)
 	}
 }
@@ -27,7 +27,7 @@ func Println(v ...interface{}) {
 // When debugging is enabled (true), debug.Printf and debug.Println will print to output.
 // Output by default is os.Stdout, and can be changed with debug.SetOutput.
 func SetDebug(b bool) {
-	enabled = b
+	Enabled = b
 }
 
 // SetOutput sets the destination for the logger.

--- a/internal/runner/rspec.go
+++ b/internal/runner/rspec.go
@@ -175,11 +175,15 @@ func (r Rspec) GetExamples(files []string) ([]plan.TestCase, error) {
 		return nil, err
 	}
 
-	cmdArgs = append(cmdArgs, "--dry-run", "--format", "progress", "--format", "json", "--out", f.Name())
+	cmdArgs = append(cmdArgs, "--dry-run", "--format", "json", "--out", f.Name())
+	if debug.Enabled {
+		cmdArgs = append(cmdArgs, "--format", "progress")
+	}
 
 	debug.Println("Running `rspec --dry-run`")
 
 	output, err := exec.Command(cmdName, cmdArgs...).CombinedOutput()
+	debug.Println(string(output))
 
 	if err != nil {
 		return []plan.TestCase{}, fmt.Errorf("failed to run rspec dry run: %s", output)

--- a/internal/runner/rspec.go
+++ b/internal/runner/rspec.go
@@ -175,7 +175,7 @@ func (r Rspec) GetExamples(files []string) ([]plan.TestCase, error) {
 		return nil, err
 	}
 
-	cmdArgs = append(cmdArgs, "--dry-run", "--format", "json", "--out", f.Name())
+	cmdArgs = append(cmdArgs, "--dry-run", "--format", "progress", "--format", "json", "--out", f.Name())
 
 	debug.Println("Running `rspec --dry-run`")
 


### PR DESCRIPTION
### Description

The dry run step output is suppressed from the terminal logs because we're using the `--out` flag for RSpec to output to a file. This makes it harder to diagnose errors when running the test splitter. This PR adds the progress formatter back in so that the dry run output is also logged to stdout.

### Context

https://linear.app/buildkite/issue/TAT-262/bubble-up-dry-run-errors

### Testing

Dry run output will be logged to stdout in test splitter with SBE turned on.
