### PR TITLE
Add background process to fetch test plan and cancel running

### DIFF
--- a/internal/runner/rspec.go
+++ b/internal/runner/rspec.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -141,7 +142,7 @@ type RspecReport struct {
 }
 
 // GetExamples returns an array of test examples within the given files.
-func (r Rspec) GetExamples(files []string) ([]plan.TestCase, error) {
+func (r Rspec) GetExamples(ctx context.Context, files []string) ([]plan.TestCase, error) {
 	// Create a temporary file to store the JSON output of the rspec dry run.
 	// We cannot simply read the dry run output from stdout because
 	// users may have custom formatters that do not output JSON.
@@ -157,11 +158,11 @@ func (r Rspec) GetExamples(files []string) ([]plan.TestCase, error) {
 		return nil, err
 	}
 
-	cmdArgs = append(cmdArgs, "--dry-run", "--format", "json", "--out", f.Name())
+	cmdArgs = append(cmdArgs, "--format", "json", "--out", f.Name())
 
 	debug.Println("Running `rspec --dry-run`")
 
-	output, err := exec.Command(cmdName, cmdArgs...).CombinedOutput()
+	output, err := exec.CommandContext(ctx, cmdName, cmdArgs...).CombinedOutput()
 
 	if err != nil {
 		return []plan.TestCase{}, fmt.Errorf("failed to run rspec dry run: %s", output)

--- a/internal/runner/rspec_test.go
+++ b/internal/runner/rspec_test.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"context"
 	"errors"
 	"os"
 	"testing"
@@ -157,7 +158,7 @@ func TestRspecDiscoveryPattern_ExcludePattern(t *testing.T) {
 func TestRspecGetExamples(t *testing.T) {
 	rspec := NewRspec("rspec")
 	files := []string{"./fixtures/spec/spells/expelliarmus_spec.rb"}
-	got, err := rspec.GetExamples(files)
+	got, err := rspec.GetExamples(context.Background(), files)
 
 	want := []plan.TestCase{
 		{
@@ -214,7 +215,7 @@ func TestRspecGetExamples_WithOtherFormatters(t *testing.T) {
 	commands := []string{"rspec --format documentation", "rspec --format html", withOtherJson}
 	for _, command := range commands {
 		rspec := NewRspec(command)
-		got, err := rspec.GetExamples(files)
+		got, err := rspec.GetExamples(context.Background(), files)
 
 		t.Run(command, func(t *testing.T) {
 


### PR DESCRIPTION
### Description
Currently, when the test plan is missing from the cache (i.e. `GET /test_plan` return `NotFound`), the client will attempt to create a new plan. The process to create a new plan might take long, especially when the Split By Example is enabled, because the client will execute dry run to get the list of examples. While the client is attempting to create a new plan, we want the client to fetch the test plan periodically in the background in case the other node successfully created the plan. If the plan is found in the background, the client should cancel all process to create a new plan.

### Changes
Fetch test plan in the background and cancel ongoing test plan creation process.
