### PR TITLE
Publish Docker image to Buildkite Packages and Dockerhub

### DIFF
--- a/.buildkite/pipeline.release.nightly.yml
+++ b/.buildkite/pipeline.release.nightly.yml
@@ -1,0 +1,2 @@
+- name: ":buildkite: :package: Publish Docker image to Buildkite Packages"
+  command: ".buildkite/steps/release-buildkite-packages.sh"

--- a/.buildkite/pipeline.release.stable.yml
+++ b/.buildkite/pipeline.release.stable.yml
@@ -1,0 +1,26 @@
+- name: ":buildkite: :package: Publish Docker image to Buildkite Packages"
+  command: ".buildkite/steps/release-buildkite-packages.sh"
+
+- wait 
+
+- block: ":rocket: Create stable release?"
+  key: create-release
+  blocked_state: "passed"
+
+- name: ":octocat: :rocket: Create Github Release"
+  command: ".buildkite/steps/release-github.sh"
+  depends_on: create-release
+  plugins:
+    - aws-assume-role-with-web-identity:
+        role-arn: arn:aws:iam::445615400570:role/pipeline-buildkite-test-splitter-client-release
+    - aws-ssm#v1.0.0:
+        parameters:
+          GH_TOKEN: /pipelines/buildkite/test-splitter-client-release/GH_TOKEN
+    - docker-compose#v4.14.0:
+        config: .buildkite/docker-compose.yml
+        cli-version: 2
+        run: release
+        mount-checkout: true
+        mount-buildkite-agent: true
+        env:
+          - GH_TOKEN

--- a/.buildkite/pipeline.release.stable.yml
+++ b/.buildkite/pipeline.release.stable.yml
@@ -24,3 +24,14 @@
         mount-buildkite-agent: true
         env:
           - GH_TOKEN
+
+- name: ":docker: :rocket: Push Docker image to Docker Hub"
+  command: ".buildkite/steps/release-dockerhub.sh"
+  depends_on: create-release
+  plugins:
+    - aws-assume-role-with-web-identity:
+        role-arn: arn:aws:iam::445615400570:role/pipeline-buildkite-test-splitter-client-release
+    - aws-ssm#v1.0.0:
+        parameters:
+          DOCKERHUB_USER: /pipelines/buildkite/test-splitter-client-release/dockerhub-user
+          DOCKERHUB_PASSWORD: /pipelines/buildkite/test-splitter-client-release/dockerhub-password

--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -1,17 +1,3 @@
 steps:
-  - name: ":octocat: :rocket: Create Github Release"
-    command: ".buildkite/steps/github-release.sh"
-    plugins:
-      - aws-assume-role-with-web-identity:
-          role-arn: arn:aws:iam::445615400570:role/pipeline-buildkite-test-splitter-client-release
-      - aws-ssm#v1.0.0:
-          parameters:
-            GH_TOKEN: /pipelines/buildkite/test-splitter-client-release/GH_TOKEN
-      - docker-compose#v4.14.0:
-          config: .buildkite/docker-compose.yml
-          cli-version: 2
-          run: release
-          mount-checkout: true
-          mount-buildkite-agent: true
-          env:
-            - GH_TOKEN
+  - name: ":cook: Prepare release"
+    command: ".buildkite/steps/release-prepare.sh"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -22,11 +22,11 @@ steps:
 
   - wait
 
-  - group: ":hammer_and_wrench: Binary builds"
+  - group: ":hammer_and_wrench: Build Binaries"
     steps:
     - name: ":{{matrix.os}}: Build {{matrix.os}} {{matrix.arch}} binary"
       command: ".buildkite/steps/build-binary.sh {{matrix.os}} {{matrix.arch}}"
-      key: build-binary
+      key: build-binaries
       artifact_paths: "pkg/*"
       plugins:
         docker-compose#v4.14.0:

--- a/.buildkite/steps/release-buildkite-packages.sh
+++ b/.buildkite/steps/release-buildkite-packages.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+version=$(buildkite-agent meta-data get "version")
+image_tag="packages.buildkite.com/buildkite/test-splitter-docker/test-splitter:${version}"
+
+echo "--- :key: Login to Buildkite Packages"
+buildkite-agent oidc request-token \
+  --audience "https://packages.buildkite.com/buildkite/test-splitter-docker" \
+  --lifetime 300 \
+  | docker login packages.buildkite.com/buildkite/test-splitter-docker --username=buildkite --password-stdin
+
+echo "--- :package: Downloading built binaries"
+buildkite-agent artifact download "pkg/test-splitter-*" .
+
+echo "--- :test_tube: Building and testing Docker image"
+docker build -t "$image_tag" ./pkg
+docker run --rm "$image_tag" --version
+
+echo "--- :docker: Pushing Docker image"
+docker push $image_tag

--- a/.buildkite/steps/release-dockerhub.sh
+++ b/.buildkite/steps/release-dockerhub.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+version=$(buildkite-agent meta-data get "version")
+image_tag="buildkite/test-splitter:${version}"
+
+echo "--- :key: Login to Dockerhub"
+echo ${DOCKERHUB_PASSWORD} | docker login --username=${DOCKERHUB_USER} --password-stdin
+
+echo "--- :package: Downloading built binaries"
+buildkite-agent artifact download "pkg/test-splitter-*" .
+
+echo "--- :docker: Pushing Docker image"
+docker buildx create --use
+docker buildx build -t $image_tag --platform linux/amd64,linux/arm64 ./pkg

--- a/.buildkite/steps/release-github.sh
+++ b/.buildkite/steps/release-github.sh
@@ -2,13 +2,7 @@
 
 set -euo pipefail
 
-splitter_version="$(cat version/VERSION)" 
-
-# Skip release if version already exists
-if git ls-remote --tags origin | grep "refs/tags/v${splitter_version}" ; then
-  echo "Version ${splitter_version} already exists"
-  exit 0
-fi
+splitter_version="$(buildkite-agent meta-data get "version")" 
 
 echo "--- :package: Downloading built binaries"
 buildkite-agent artifact download "pkg/test-splitter-*" .

--- a/.buildkite/steps/release-prepare.sh
+++ b/.buildkite/steps/release-prepare.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+version="$(cat version/VERSION)"
+
+echo "--- :label: Checking git tag"
+
+# If the tag is already exists, we assume the release is for nightly build,
+# otherwise we assume it's a stable release
+if git ls-remote --tags origin | grep "refs/tags/v${version}" ; then
+  echo "v${version} already exists, running nightly release"
+  buildkite-agent meta-data set "release-phase" "nightly"
+  buildkite-agent meta-data set "version" "$version-$(git rev-parse --short HEAD)"
+  buildkite-agent pipeline upload .buildkite/pipeline.release.nightly.yml
+else
+  echo "v${version} does not exist, running stable release"
+  buildkite-agent meta-data set "release-phase" "stable"
+  buildkite-agent meta-data set "version" "$version"
+  buildkite-agent pipeline upload .buildkite/pipeline.release.stable.yml
+fi

--- a/pkg/Dockerfile
+++ b/pkg/Dockerfile
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/docker/library/alpine:3.20.1@sha256:b89d9c93e9ed3597455c90a0b88a8bbb5cb7188438f70953fede212a0c4394e0
+
+ARG TARGETOS
+ARG TARGETARCH
+
+COPY ./test-splitter-$TARGETOS-$TARGETARCH /usr/local/bin/test-splitter
+RUN chmod +x /usr/local/bin/test-splitter
+
+ENTRYPOINT ["test-splitter"]


### PR DESCRIPTION
### Description
We want to create a Docker image that contains `test-splitter` binary and publish it to Dockerhub during the release.
We also want to create a nightly build image and publish it to private Buildkite Packages repo for internal use.

This PR introduce a branching in the release pipeline that will upload different sets of job depending on release. phase
1. Nightly build. Triggered when the tag for the version is already exists in git
   - Push docker image to Buildkite Packages
   - The image tag will have version number and short commit sha, e.g. `0.7.7-aa0e23`.
1. Stable. Triggered when the tag for the version is **not** already exists in git
   - Push docker image to Buildkite Packages
   - Push docker image to Dockerhub
   - Create GitHub Release
   - The image tag will only have version number, e.g. `0.7.7`.

I also added a block step as a safety mechanism before running the job to create GitHub Release, publish to Dockerhub, and to other potential public distribution in the future.
 

Following graph shows the build flow for `Test Spliter Client - Release` pipeline, that will be triggered on _every_ commit in `main` branch.

![image](https://github.com/user-attachments/assets/ffcbec7f-c682-4a42-89e9-5fa748467062)


### Verification
I triggered a build in `Test Splitter Client - Release` for this branch, and this is how the [build](https://buildkite.com/buildkite/test-splitter-client-release/builds/108) looks like for nightly build.


