### PR TITLE
Hard-exit the test splitter if the runner exits abnormally, e.g. SIGABRT

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,18 @@ steps:
     env:
       BUILDKITE_SPLITTER_SUITE_SLUG: my-suite
       BUILDKITE_SPLITTER_API_ACCESS_TOKEN: your-secret-token
-``` 
+```
 
-### Exit code
-| Exit code | Description |
-| ---- | ---- |
-| 0 | Success (passed through from test runner) |
-| 1 | Failure (passed through from test runner) |
-| 16 | Test Splitter failure (e.g., config error) |
-| * | Other errors (passed through from the test runner) |
+### Possible exit statuses
+
+The test-splitter client may exit with a variety of exit statuses, outlined below:
+
+- If there is a configuration error, the test-splitter client will exit with
+  status 16.
+- If the test-splitter runner (such as RSpec) exits cleanly, the exit status of
+  the runner is returned. This will likely be 0 for successful test runs, 1 for
+  failing test runs, but may be any other error status returned by the runner.
+- If the test-splitter runner raises an OS level signal, such as SIGSEGV or
+  SIGABRT, the exit status returned will be equal to 128 plus the signal number.
+  For example, if the runner raises a SIGSEGV, the exit status will be (128 +
+  11) = 139.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The test-splitter client may exit with a variety of exit statuses, outlined belo
 - If the test-splitter runner (such as RSpec) exits cleanly, the exit status of
   the runner is returned. This will likely be 0 for successful test runs, 1 for
   failing test runs, but may be any other error status returned by the runner.
-- If the test-splitter runner raises an OS level signal, such as SIGSEGV or
+- If the test-splitter runner is terminated by an OS level signal, such as SIGSEGV or
   SIGABRT, the exit status returned will be equal to 128 plus the signal number.
   For example, if the runner raises a SIGSEGV, the exit status will be (128 +
   11) = 139.

--- a/go.mod
+++ b/go.mod
@@ -11,13 +11,13 @@ require (
 	github.com/DrJosh9000/zzglob v0.2.0
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/pact-foundation/pact-go/v2 v2.0.5
+	golang.org/x/sys v0.18.0
 )
 
 require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/stretchr/testify v1.9.0 // indirect
 	golang.org/x/net v0.23.0 // indirect
-	golang.org/x/sys v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240227224415-6ceb2ff114de // indirect
 	google.golang.org/grpc v1.63.2 // indirect

--- a/internal/runner/rspec.go
+++ b/internal/runner/rspec.go
@@ -30,6 +30,10 @@ func NewRspec(testCommand string) Rspec {
 	}
 }
 
+func (r Rspec) Name() string {
+	return "RSpec"
+}
+
 // GetFiles returns an array of file names using the discovery pattern.
 func (r Rspec) GetFiles() ([]string, error) {
 	pattern := r.discoveryPattern()


### PR DESCRIPTION
### Description

We have an exit status problem with the test splitter if the runner exits abnormally due to an OS-level signal (SIGSEGV or some such).

This PR adds signal detection to both the runner and the retries to exit more cleanly if the runner fails miserably to execute.

### Context

Linear: https://linear.app/buildkite/issue/TAT-268/nuclear-rspec-command-should-not-be-retried

### Changes

- Handle signals in the runner and exit cleanly from the test splitter with an exit status equal to 128 + the signal number.
- Update the README.md file to reflect these changes.

### Testing

Tested locally with `test-splitter-integration-testing` repository. Will cause bk/bk builds to fail on the coredump error instead of job-level retries as the exit codes are not clear. This will be handled in bk/bk before shipping the upgrade PR.
