### PR TITLE
If err != nil, don't discover that path

### DIFF
--- a/internal/runner/discover.go
+++ b/internal/runner/discover.go
@@ -29,7 +29,8 @@ func discoverTestFiles(pattern DiscoveryPattern) ([]string, error) {
 	// and append the matched file paths to the discoveredFiles slice
 	parsedPattern.Glob(func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			fmt.Printf("Error walking: %v\n", err)
+			fmt.Printf("Error walking at path %q: %v\n", path, err)
+			return nil
 		}
 
 		// Check if the path matches the exclude pattern. If so, skip it.


### PR DESCRIPTION
### Description

To enable debugging things like permissions issues that prevent Glob from walking a directory that matches the pattern, Glob calls the callback with paths if there was an error. This currently happens even with file paths that don't fully match the pattern (a zzglob bug). 

Regardless, errors being passed into the callback should cause the path to not be discovered.

### Context

Bug report from beta user

### Changes

`return nil` within the error handling block.

### Testing

No additional testing