### PR TITLE
Upgrade zzglob to v0.3.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/buildkite/test-splitter
 
-go 1.20
+go 1.21
+
+toolchain go1.22.4
 
 require (
 	github.com/buildkite/roko v1.2.0
@@ -8,7 +10,7 @@ require (
 )
 
 require (
-	github.com/DrJosh9000/zzglob v0.2.0
+	github.com/DrJosh9000/zzglob v0.3.1
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/pact-foundation/pact-go/v2 v2.0.5
 	golang.org/x/sys v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,9 @@
-github.com/DrJosh9000/zzglob v0.2.0 h1:/emTm1QHFXZZlRark33J8KiHrSNMIXDYXVY0jDjsSa4=
-github.com/DrJosh9000/zzglob v0.2.0/go.mod h1:+iLI/qvROFsS1A/jl+B8MVYNu/0cjveYOJqU37O8fcs=
+github.com/DrJosh9000/zzglob v0.3.1 h1:Ffthy/AxQ6nyEC3c7n3qGCd4CajZWMrdYjcdaYXTFeI=
+github.com/DrJosh9000/zzglob v0.3.1/go.mod h1:rMssZ45uIKN5WFJWLonPnC+fJTULGts9mjM7JjdF7UI=
 github.com/buildkite/roko v1.2.0 h1:hbNURz//dQqNl6Eo9awjQOVOZwSDJ8VEbBDxSfT9rGQ=
 github.com/buildkite/roko v1.2.0/go.mod h1:23R9e6nHxgedznkwwfmqZ6+0VJZJZ2Sg/uVcp2cP46I=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
@@ -12,6 +13,7 @@ github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:C
 github.com/pact-foundation/pact-go/v2 v2.0.5 h1:t7Ngeug5TYYREKYBLAb+jmNUB84mJdBNTYRAfPLyY90=
 github.com/pact-foundation/pact-go/v2 v2.0.5/go.mod h1:OO003128Co8mczCV7UrD6kmeCdyxFOAv4dt3BFvqy5E=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
@@ -27,4 +29,6 @@ google.golang.org/grpc v1.63.2/go.mod h1:WAX/8DgncnokcFUldAxq7GeB5DXHDbMF+lLvDom
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools/v3 v3.5.1 h1:EENdUnS3pdur5nybKYIh2Vfgc8IUNBjxDPSjtiJcOzU=
+gotest.tools/v3 v3.5.1/go.mod h1:isy3WKz7GK6uNw/sbHzfKBLvlvXwUyV06n6brMxxopU=


### PR DESCRIPTION
### Description

I released a new zzglob. This had knock-on effects in go.mod that should be uncontentious (splitter uses Go 1.21 to compile).

### Changes

* `go get github.com/DrJosh9000/zzglob@v0.3.1`
* `go mod tidy`

### Testing

No extra testing
