### PR TITLE
Add more logging for file discovery when in debug mode

### DIFF
--- a/internal/runner/rspec.go
+++ b/internal/runner/rspec.go
@@ -40,7 +40,9 @@ func (r Rspec) Name() string {
 func (r Rspec) GetFiles() ([]string, error) {
 	pattern := r.discoveryPattern()
 
+	debug.Println("Discovering test files with include pattern:", pattern.IncludePattern, "exclude pattern:", pattern.ExcludePattern)
 	files, err := discoverTestFiles(pattern)
+	debug.Println("Discovered", len(files), "files")
 
 	// rspec test in Test Analytics is stored with leading "./"
 	// therefore, we need to add "./" to the file path


### PR DESCRIPTION
The debug logs are a bit lacking for the file discovery phase, so this makes it a bit louder.

```
2024/07/26 10:25:35 DEBUG: Discovering test files with include pattern: spec/**/*_spec.rb exclude pattern:
2024/07/26 10:25:35 DEBUG: Discovered 6 files
```