### PR TITLE
Add homebrew tap to goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,6 +20,20 @@ builds:
     goarch: [amd64, arm64]
     ldflags: "-X 'main.Version=v{{ .Version }}'"
 
+brews:
+  - name: test-splitter
+    description: "Buildkite test splitting client"
+    homepage: "https://github.com/buildkite/test-splitter"
+    skip_upload: auto
+    directory: .
+    test: |
+      version_output = shell_output("test-splitter --version")
+      assert_match "v#{version}\n", version_output
+    repository:
+      owner: buildkite
+      name: homebrew-buildkite
+      branch: master
+
 dockers:
   - image_templates:
       - "packages.buildkite.com/buildkite/test-splitter-docker/test-splitter:v{{ .Version }}-amd64"


### PR DESCRIPTION
### Description
Automate the version bumping of test-splitter client in [homebrew/buildkite](https://github.com/buildkite/homebrew-buildkite/blob/master/test-splitter.rb) repository using `goreleaser`.
After the release is created in GitHub, `goreleaser` will push commit to `homebrew/buildkite` repo to bump the version including the sha.

This is how the generated formulae looks like
```
# typed: false
# frozen_string_literal: true

# This file was generated by GoReleaser. DO NOT EDIT.
class TestSplitter < Formula
  desc "Buildkite test splitting client"
  homepage "https://github.com/buildkite/test-splitter"
  version "0.8.0"

  on_macos do
    on_intel do
      url "https://github.com/nprizal/test-splitter/releases/download/v0.8.0/test-splitter_0.8.0_darwin_amd64"
      sha256 "b677cfdd718eb0a9626b9c13cbc798a51b8dc09cc85af307148e6d6c71f6f95f"

      def install
        bin.install "test-splitter_0.8.0_darwin_amd64" => "test-splitter"
      end
    end
    on_arm do
      url "https://github.com/nprizal/test-splitter/releases/download/v0.8.0/test-splitter_0.8.0_darwin_arm64"
      sha256 "205bdac5491cf396d475cdadbb58f5dbce514e2547e54883426f89c9988283c1"

      def install
        bin.install "test-splitter_0.8.0_darwin_arm64" => "test-splitter"
      end
    end
  end

  on_linux do
    on_intel do
      if Hardware::CPU.is_64_bit?
        url "https://github.com/nprizal/test-splitter/releases/download/v0.8.0/test-splitter_0.8.0_linux_amd64"
        sha256 "28d388f93a26ff390f32f7566edf76b2630206751ac832cd0651241a27e4693b"

        def install
          bin.install "test-splitter_0.8.0_linux_amd64" => "test-splitter"
        end
      end
    end
    on_arm do
      if Hardware::CPU.is_64_bit?
        url "https://github.com/nprizal/test-splitter/releases/download/v0.8.0/test-splitter_0.8.0_linux_arm64"
        sha256 "6c2ca8036f31c5a2212850a1fb179bf9a3a2e0b9cf8597fcd13af2986dfc223f"

        def install
          bin.install "test-splitter_0.8.0_linux_arm64" => "test-splitter"
        end
      end
    end
  end

  test do
    version_output = shell_output("test-splitter --version")
    assert_match "v#{version}\n", version_output
  end
end
```

### Deployment
It requires GITHUB_TOKEN that has access to push commit to `homebrew/buildkite` repository.