### PR TITLE
Refactor test file and exclude pattern handling

### DIFF
--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -185,7 +185,7 @@ func TestDoWithRetry_RequestError(t *testing.T) {
 
 func TestDoWithRetry_429(t *testing.T) {
 	originalTimeout := retryTimeout
-	retryTimeout = 2 * time.Second
+	retryTimeout = 1500 * time.Millisecond
 	t.Cleanup(func() {
 		retryTimeout = originalTimeout
 	})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,10 @@ type Config struct {
 	SuiteSlug string
 	// TestCommand is the command to run the tests.
 	TestCommand string
+	// TestFilePattern is the pattern to match the test files.
+	TestFilePattern string
+	// TestFileExcludePattern is the pattern to exclude the test files.
+	TestFileExcludePattern string
 }
 
 // New wraps the readFromEnv and validate functions to create a new Config struct.

--- a/internal/config/read.go
+++ b/internal/config/read.go
@@ -25,6 +25,8 @@ import (
 // - BUILDKITE_SPLITTER_SPLIT_BY_EXAMPLE (SplitByExample)
 // - BUILDKITE_SPLITTER_SUITE_SLUG (SuiteSlug)
 // - BUILDKITE_SPLITTER_TEST_CMD (TestCommand)
+// - BUILDKITE_SPLITTER_TEST_FILE_PATTERN (TestFilePattern)
+// - BUILDKITE_SPLITTER_TEST_FILE_EXCLUDE_PATTERN (TestFileExcludePattern)
 //
 // If we are going to support other CI environment in the future,
 // we will need to change where we read the configuration from.
@@ -39,6 +41,8 @@ func (c *Config) readFromEnv() error {
 	c.ServerBaseUrl = getEnvWithDefault("BUILDKITE_SPLITTER_BASE_URL", "https://api.buildkite.com")
 	c.Mode = getEnvWithDefault("BUILDKITE_SPLITTER_MODE", "static")
 	c.TestCommand = os.Getenv("BUILDKITE_SPLITTER_TEST_CMD")
+	c.TestFilePattern = os.Getenv("BUILDKITE_SPLITTER_TEST_FILE_PATTERN")
+	c.TestFileExcludePattern = os.Getenv("BUILDKITE_SPLITTER_TEST_FILE_EXCLUDE_PATTERN")
 
 	c.SplitByExample = strings.ToLower(os.Getenv("BUILDKITE_SPLITTER_SPLIT_BY_EXAMPLE")) == "true"
 

--- a/internal/config/read_test.go
+++ b/internal/config/read_test.go
@@ -22,24 +22,28 @@ func TestConfigReadFromEnv(t *testing.T) {
 	os.Setenv("BUILDKITE_SPLITTER_SPLIT_BY_EXAMPLE", "TRUE")
 	os.Setenv("BUILDKITE_BUILD_ID", "123")
 	os.Setenv("BUILDKITE_STEP_ID", "456")
+	os.Setenv("BUILDKITE_SPLITTER_TEST_FILE_PATTERN", "spec/unit/**/*_spec.rb")
+	os.Setenv("BUILDKITE_SPLITTER_TEST_FILE_EXCLUDE_PATTERN", "spec/feature/**/*_spec.rb")
 	defer os.Clearenv()
 
 	c := Config{}
 	err := c.readFromEnv()
 
 	want := Config{
-		Parallelism:       10,
-		NodeIndex:         0,
-		ServerBaseUrl:     "https://buildkite.localhost",
-		Mode:              "static",
-		Identifier:        "123/456",
-		TestCommand:       "bin/rspec {{testExamples}}",
-		AccessToken:       "my_token",
-		OrganizationSlug:  "my_org",
-		SuiteSlug:         "my_suite",
-		MaxRetries:        3,
-		SplitByExample:    true,
-		SlowFileThreshold: 3 * time.Minute,
+		Parallelism:            10,
+		NodeIndex:              0,
+		ServerBaseUrl:          "https://buildkite.localhost",
+		Mode:                   "static",
+		Identifier:             "123/456",
+		TestCommand:            "bin/rspec {{testExamples}}",
+		AccessToken:            "my_token",
+		OrganizationSlug:       "my_org",
+		SuiteSlug:              "my_suite",
+		MaxRetries:             3,
+		SplitByExample:         true,
+		SlowFileThreshold:      3 * time.Minute,
+		TestFilePattern:        "spec/unit/**/*_spec.rb",
+		TestFileExcludePattern: "spec/feature/**/*_spec.rb",
 	}
 
 	if err != nil {

--- a/internal/runner/discover.go
+++ b/internal/runner/discover.go
@@ -7,20 +7,15 @@ import (
 	"github.com/DrJosh9000/zzglob"
 )
 
-type DiscoveryPattern struct {
-	IncludePattern string
-	ExcludePattern string
-}
-
-func discoverTestFiles(pattern DiscoveryPattern) ([]string, error) {
-	parsedPattern, err := zzglob.Parse(pattern.IncludePattern)
+func discoverTestFiles(pattern string, excludePattern string) ([]string, error) {
+	parsedPattern, err := zzglob.Parse(pattern)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing test file pattern %q", pattern)
 	}
 
-	parsedExcludePattern, err := zzglob.Parse(pattern.ExcludePattern)
+	parsedExcludePattern, err := zzglob.Parse(excludePattern)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing test file exclude pattern %q", pattern.ExcludePattern)
+		return nil, fmt.Errorf("error parsing test file exclude pattern %q", excludePattern)
 	}
 
 	discoveredFiles := []string{}

--- a/internal/runner/discover_test.go
+++ b/internal/runner/discover_test.go
@@ -8,10 +8,7 @@ import (
 
 func TestDiscoverTestFiles(t *testing.T) {
 	pattern := "fixtures/**/*_test"
-	got, err := discoverTestFiles(DiscoveryPattern{
-		IncludePattern: pattern,
-		ExcludePattern: "",
-	})
+	got, err := discoverTestFiles(pattern, "")
 
 	if err != nil {
 		t.Errorf("discoverTestFiles(%q, %q) error: %v", pattern, "", err)
@@ -33,10 +30,7 @@ func TestDiscoverTestFiles(t *testing.T) {
 func TestDiscoverTestFiles_WithExcludePattern(t *testing.T) {
 	pattern := "fixtures/**/*_test"
 	excludePattern := "fixtures/animals/*"
-	got, err := discoverTestFiles(DiscoveryPattern{
-		IncludePattern: pattern,
-		ExcludePattern: excludePattern,
-	})
+	got, err := discoverTestFiles(pattern, excludePattern)
 
 	if err != nil {
 		t.Errorf("discoverTestFiles(%q, %q) error: %v", pattern, excludePattern, err)
@@ -56,10 +50,7 @@ func TestDiscoverTestFiles_WithExcludePattern(t *testing.T) {
 func TestDiscoverTestFiles_WithExcludeDirectory(t *testing.T) {
 	pattern := "fixtures/**/*_test"
 	excludePattern := "fixtures/animals"
-	got, err := discoverTestFiles(DiscoveryPattern{
-		IncludePattern: pattern,
-		ExcludePattern: excludePattern,
-	})
+	got, err := discoverTestFiles(pattern, excludePattern)
 
 	if err != nil {
 		t.Errorf("discoverTestFiles(%q, %q) error: %v", pattern, excludePattern, err)

--- a/main.go
+++ b/main.go
@@ -51,7 +51,12 @@ func main() {
 	}
 
 	// TODO: detect test runner and use appropriate runner
-	testRunner := runner.NewRspec(cfg.TestCommand, cfg.RetryCommand)
+	testRunner := runner.NewRspec(runner.Rspec{
+		TestCommand:            cfg.TestCommand,
+		TestFilePattern:        cfg.TestFilePattern,
+		TestFileExcludePattern: cfg.TestFileExcludePattern,
+		RetryTestCommand:       cfg.RetryCommand,
+	})
 
 	files, err := testRunner.GetFiles()
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -19,7 +19,9 @@ import (
 )
 
 func TestRetryFailedTests(t *testing.T) {
-	testRunner := runner.NewRspec("true", "")
+	testRunner := runner.Rspec{
+		TestCommand: "true",
+	}
 	maxRetries := 3
 	timeline := []api.Timeline{}
 	exitCode := retryFailedTests(testRunner, maxRetries, &timeline)
@@ -34,7 +36,9 @@ func TestRetryFailedTests(t *testing.T) {
 }
 
 func TestRetryFailedTests_Failure(t *testing.T) {
-	testRunner := runner.NewRspec("false", "")
+	testRunner := runner.Rspec{
+		TestCommand: "false",
+	}
 	maxRetries := 3
 	timeline := []api.Timeline{}
 	exitCode := retryFailedTests(testRunner, maxRetries, &timeline)
@@ -50,7 +54,7 @@ func TestRetryFailedTests_Failure(t *testing.T) {
 
 func TestFetchOrCreateTestPlan(t *testing.T) {
 	files := []string{"apple"}
-	testRunner := runner.NewRspec("", "")
+	testRunner := runner.Rspec{}
 
 	// mock server to return a test plan
 	response := `{
@@ -158,7 +162,7 @@ func TestFetchOrCreateTestPlan_CachedPlan(t *testing.T) {
 	})
 
 	tests := []string{"banana"}
-	testRunner := runner.NewRspec("", "")
+	testRunner := runner.Rspec{}
 
 	want := plan.TestPlan{
 		Tasks: map[string]*plan.Task{
@@ -180,7 +184,7 @@ func TestFetchOrCreateTestPlan_CachedPlan(t *testing.T) {
 
 func TestFetchOrCreateTestPlan_PlanError(t *testing.T) {
 	files := []string{"apple", "banana", "cherry", "mango"}
-	TestRunner := runner.NewRspec("", "")
+	TestRunner := runner.Rspec{}
 
 	// mock server to return an error plan
 	response := `{
@@ -216,7 +220,7 @@ func TestFetchOrCreateTestPlan_PlanError(t *testing.T) {
 
 func TestFetchOrCreateTestPlan_InternalServerError(t *testing.T) {
 	files := []string{"red", "orange", "yellow", "green", "blue", "indigo", "violet"}
-	testRunner := runner.NewRspec("", "")
+	testRunner := runner.Rspec{}
 
 	// mock server to return a 500 Internal Server Error
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -253,7 +257,7 @@ func TestFetchOrCreateTestPlan_InternalServerError(t *testing.T) {
 
 func TestFetchOrCreateTestPlan_BadRequest(t *testing.T) {
 	files := []string{"apple", "banana"}
-	testRunner := runner.NewRspec("", "")
+	testRunner := runner.Rspec{}
 
 	// mock server to return 400 Bad Request
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -294,7 +298,7 @@ func TestCreateRequestParams_SplitByFile(t *testing.T) {
 	}
 
 	client := api.NewClient(api.ClientConfig{})
-	got, err := createRequestParam(context.Background(), cfg, []string{"apple", "banana"}, *client, runner.NewRspec("", ""))
+	got, err := createRequestParam(context.Background(), cfg, []string{"apple", "banana"}, *client, runner.Rspec{})
 	want := api.TestPlanParams{
 		Identifier:  "identifier",
 		Parallelism: 7,
@@ -352,7 +356,9 @@ func TestCreateRequestParams_SplitByExample(t *testing.T) {
 		"test/spec/fruits/grape_spec.rb",
 	}
 
-	got, err := createRequestParam(context.Background(), cfg, files, *client, runner.NewRspec("rspec", ""))
+	got, err := createRequestParam(context.Background(), cfg, files, *client, runner.Rspec{
+		TestCommand: "rspec",
+	})
 
 	if err != nil {
 		t.Errorf("createRequestParam() error = %v", err)
@@ -427,7 +433,7 @@ func TestCreateRequestParams_SplitByExample_NoFileTiming(t *testing.T) {
 		"grape_spec.rb",
 	}
 
-	_, err := createRequestParam(context.Background(), cfg, files, *client, runner.NewRspec("", ""))
+	_, err := createRequestParam(context.Background(), cfg, files, *client, runner.Rspec{})
 
 	if err == nil {
 		t.Errorf("createRequestParam() want error, got nil")
@@ -469,7 +475,9 @@ func TestCreateRequestParams_SplitByExample_MissingSomeOfTiming(t *testing.T) {
 		"test/spec/fruits/grape_spec.rb",
 	}
 
-	got, err := createRequestParam(context.Background(), cfg, files, *client, runner.NewRspec("rspec", ""))
+	got, err := createRequestParam(context.Background(), cfg, files, *client, runner.Rspec{
+		TestCommand: "rspec",
+	})
 
 	if err != nil {
 		t.Errorf("createRequestParam() error = %v", err)
@@ -546,7 +554,9 @@ func TestCreateRequestParams_SplitByExample_NoSlowFiles(t *testing.T) {
 		"test/spec/fruits/grape_spec.rb",
 	}
 
-	got, err := createRequestParam(context.Background(), cfg, files, *client, runner.NewRspec("rspec", ""))
+	got, err := createRequestParam(context.Background(), cfg, files, *client, runner.Rspec{
+		TestCommand: "rspec",
+	})
 
 	if err != nil {
 		t.Errorf("createRequestParam() error = %v", err)


### PR DESCRIPTION
Currently, the `BUILDKITE_SPLITTER_TEST_FILE_PATTERN` and `BUILDKITE_SPLITTER_TEST_FILE_EXCLUDE_PATTERN` are fetched from runner/rspec.go. To be consistent with other config, I moved the fetching to the `config/read.go`.

The default value for include pattern still be defined in `runner/rspec.go`.