### PR TITLE
Publish test splitter client as linux packages

### DIFF
--- a/.buildkite/steps/upload-linux-packages.sh
+++ b/.buildkite/steps/upload-linux-packages.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+
+file=${1}
+extension="${file##*.}"
+registry="test-splitter-${extension}"
+audience="https://packages.buildkite.com/buildkite/${registry}"
+
+echo "--- :key: :buildkite: Fetching OIDC token for ${audience}"
+token=$(buildkite-agent oidc request-token --audience "${audience}" --lifetime 180)
+
+echo "--- :linux: Uploading ${file}"
+curl -s -X POST "https://api.buildkite.com/v2/packages/organizations/buildkite/registries/${registry}/packages" \
+      -H "Authorization: Bearer ${token}" \
+      -F "file=@${file}" \
+    --fail-with-body

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -68,3 +68,16 @@ docker_manifests:
       - "buildkite/test-splitter:v{{ .Version }}-arm64"
     # skip pushing latest tag to Dockerhub if it's a prerelease  
     skip_push: auto
+
+nfpms:
+  - vendor: Buildkite
+    homepage: https://github.com/buildkite/test-splitter
+    maintainer: Buildkite <support@buildkite.com>
+    description: Buildkite test splitting client
+    license: MIT
+    formats:
+      - apk
+      - deb
+      - rpm
+    provides:
+      - test-splitter

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -77,12 +77,10 @@ nfpms:
     description: Buildkite test splitting client
     license: MIT
     formats:
-      - apk
       - deb
       - rpm
     provides:
       - test-splitter
-    release: 0
 
 publishers:
   - name: buildkite-packages

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -71,6 +71,7 @@ docker_manifests:
 
 nfpms:
   - vendor: Buildkite
+    id: linux-pkg
     homepage: https://github.com/buildkite/test-splitter
     maintainer: Buildkite <support@buildkite.com>
     description: Buildkite test splitting client
@@ -81,3 +82,14 @@ nfpms:
       - rpm
     provides:
       - test-splitter
+    release: 0
+
+publishers:
+  - name: buildkite-packages
+    disable: "{{if .Prerelease}}true{{end}}"
+    cmd: .buildkite/steps/upload-linux-packages.sh {{ .ArtifactPath }}
+    ids:
+      - linux-pkg
+    env:
+      - BUILDKITE_JOB_ID={{ .Env.BUILDKITE_JOB_ID }}
+      - BUILDKITE_AGENT_ACCESS_TOKEN={{ .Env.BUILDKITE_AGENT_ACCESS_TOKEN }}


### PR DESCRIPTION
### Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->
Publish _stable_ version public Buildkite Packages repositories.
- ~[Alpine (apk)](https://buildkite.com/organizations/buildkite/packages/registries/test-splitter-apk)~ Skip for now, as there is issue publishing alpine package.
- [Debian (deb)](https://buildkite.com/organizations/buildkite/packages/registries/test-splitter-deb)
- [Red Hat (rpm)](https://buildkite.com/organizations/buildkite/packages/registries/test-splitter-rpm)

The packages are uploaded using `goreleaser` custom publisher.

### Verification
I have tested the pipeline, and this is the successful [build](https://buildkite.com/buildkite/test-splitter-client-release/builds/164#019105c8-4699-437a-a483-41ac6eb0d0a2). I have removed the published packages from that build.