### PR TITLE
Add ice cream flavour to debug logs.

### DIFF
--- a/internal/plan/type.go
+++ b/internal/plan/type.go
@@ -25,5 +25,6 @@ type Task struct {
 
 // TestPlan represents the entire test plan.
 type TestPlan struct {
-	Tasks map[string]*Task `json:"tasks"`
+	Experiment string           `json:"experiment"`
+	Tasks      map[string]*Task `json:"tasks"`
 }

--- a/main.go
+++ b/main.go
@@ -77,6 +77,8 @@ func main() {
 		logErrorAndExit(16, "Couldn't fetch or create test plan: %v", err)
 	}
 
+	debug.Printf("My favourite ice cream is %s", testPlan.Experiment)
+
 	// get plan for this node
 	thisNodeTask := testPlan.Tasks[strconv.Itoa(cfg.NodeIndex)]
 


### PR DESCRIPTION
### Description

Who doesn't like ice cream? This makes it a little bit easier to see which ice cream flavour the test plan belongs to.

### Testing

I've verified that the output contains the right line:

```
2024/08/05 12:48:10 DEBUG: Response code 200
2024/08/05 12:48:10 DEBUG: Test plan created. Identifier: "build_id/step_id_3833"
2024/08/05 12:48:10 DEBUG: My favourite ice cream is vanilla
+++ Buildkite Test Splitter: Running tests
bundle exec rspec ./spec/all_passing/one_spec.rb:4 ./spec/split_by_example/slow_spec.rb:8 ./spec/split_by_example/fast_spec.rb
Run options: include {:locations=>{"./spec/all_passing/one_spec.rb"=>[4], "./spec/split_by_example/slow_spec.rb"=>[8]}}
```
