### PR TITLE
Shuffle things around in preparation for Jest runner.

### DIFF
--- a/internal/runner/detector.go
+++ b/internal/runner/detector.go
@@ -23,7 +23,7 @@ type TestRunner interface {
 }
 
 func DetectRunner(runner string, cfg RunnerConfig) (TestRunner, error) {
-	switch cfg.TestRunner {
+	switch runner {
 	case "rspec":
 		return NewRspec(cfg), nil
 	default:

--- a/internal/runner/detector.go
+++ b/internal/runner/detector.go
@@ -8,10 +8,10 @@ import (
 )
 
 type RunnerConfig struct {
-  TestCommand string
-  TestFilePattern string
-  TestFileExcludePattern string
-  RetryTestCommand string
+	TestCommand            string
+	TestFilePattern        string
+	TestFileExcludePattern string
+	RetryTestCommand       string
 }
 
 type TestRunner interface {

--- a/internal/runner/detector.go
+++ b/internal/runner/detector.go
@@ -2,11 +2,21 @@ package runner
 
 import (
 	"errors"
+	"os/exec"
 
 	"github.com/buildkite/test-splitter/internal/config"
+	"github.com/buildkite/test-splitter/internal/plan"
 )
 
-func DetectRunner(cfg config.Config) (*Rspec, error) {
+type TestRunner interface {
+	Command(testCases []string) (*exec.Cmd, error)
+	GetExamples(files []string) ([]plan.TestCase, error)
+	GetFiles() ([]string, error)
+	RetryCommand() (*exec.Cmd, error)
+	Name() string
+}
+
+func DetectRunner(cfg config.Config) (TestRunner, error) {
 	switch cfg.TestRunner {
 	case "rspec":
 		return NewRspec(Rspec{

--- a/internal/runner/detector.go
+++ b/internal/runner/detector.go
@@ -4,9 +4,15 @@ import (
 	"errors"
 	"os/exec"
 
-	"github.com/buildkite/test-splitter/internal/config"
 	"github.com/buildkite/test-splitter/internal/plan"
 )
+
+type RunnerConfig struct {
+  TestCommand string
+  TestFilePattern string
+  TestFileExcludePattern string
+  RetryTestCommand string
+}
 
 type TestRunner interface {
 	Command(testCases []string) (*exec.Cmd, error)
@@ -16,15 +22,10 @@ type TestRunner interface {
 	Name() string
 }
 
-func DetectRunner(cfg config.Config) (TestRunner, error) {
+func DetectRunner(runner string, cfg RunnerConfig) (TestRunner, error) {
 	switch cfg.TestRunner {
 	case "rspec":
-		return NewRspec(Rspec{
-			TestCommand:            cfg.TestCommand,
-			TestFilePattern:        cfg.TestFilePattern,
-			TestFileExcludePattern: cfg.TestFileExcludePattern,
-			RetryTestCommand:       cfg.RetryCommand,
-		}), nil
+		return NewRspec(cfg), nil
 	default:
 		return nil, errors.New("Runner value is invalid, possible values are 'rspec'")
 	}

--- a/internal/runner/rspec.go
+++ b/internal/runner/rspec.go
@@ -20,7 +20,7 @@ type Rspec struct {
 	cfg RunnerConfig
 }
 
-func NewRspec(cfg *RunnerConfig) *Rspec {
+func NewRspec(cfg RunnerConfig) Rspec {
 	if cfg.TestCommand == "" {
 		cfg.TestCommand = "bundle exec rspec {{testExamples}}"
 	}
@@ -40,8 +40,8 @@ func (r Rspec) Name() string {
 
 // GetFiles returns an array of file names using the discovery pattern.
 func (r Rspec) GetFiles() ([]string, error) {
-	debug.Println("Discovering test files with include pattern:", r.TestFilePattern, "exclude pattern:", r.TestFileExcludePattern)
-	files, err := discoverTestFiles(r.TestFilePattern, r.TestFileExcludePattern)
+	debug.Println("Discovering test files with include pattern:", r.cfg.TestFilePattern, "exclude pattern:", r.cfg.TestFileExcludePattern)
+	files, err := discoverTestFiles(r.cfg.TestFilePattern, r.cfg.TestFileExcludePattern)
 	debug.Println("Discovered", len(files), "files")
 
 	// rspec test in Test Analytics is stored with leading "./"
@@ -56,7 +56,7 @@ func (r Rspec) GetFiles() ([]string, error) {
 	}
 
 	if len(files) == 0 {
-		return nil, fmt.Errorf("no files found with pattern %q and exclude pattern %q", r.TestFilePattern, r.TestFileExcludePattern)
+		return nil, fmt.Errorf("no files found with pattern %q and exclude pattern %q", r.cfg.TestFilePattern, r.cfg.TestFileExcludePattern)
 	}
 
 	return files, nil

--- a/internal/runner/rspec.go
+++ b/internal/runner/rspec.go
@@ -30,7 +30,7 @@ func NewRspec(cfg *RunnerConfig) *Rspec {
 	}
 
 	return Rspec{
-		cfg: cfg
+		cfg: cfg,
 	}
 }
 

--- a/internal/runner/rspec.go
+++ b/internal/runner/rspec.go
@@ -17,22 +17,21 @@ import (
 // For now, Rspec provides rspec specific behaviour to execute
 // and report on tests in the Rspec framework.
 type Rspec struct {
-	TestCommand            string
-	TestFileExcludePattern string
-	TestFilePattern        string
-	RetryTestCommand       string
+	cfg RunnerConfig
 }
 
-func NewRspec(r Rspec) *Rspec {
-	if r.TestCommand == "" {
-		r.TestCommand = "bundle exec rspec {{testExamples}}"
+func NewRspec(cfg *RunnerConfig) *Rspec {
+	if cfg.TestCommand == "" {
+		cfg.TestCommand = "bundle exec rspec {{testExamples}}"
 	}
 
-	if r.TestFilePattern == "" {
-		r.TestFilePattern = "spec/**/*_spec.rb"
+	if cfg.TestFilePattern == "" {
+		cfg.TestFilePattern = "spec/**/*_spec.rb"
 	}
 
-	return &r
+	return Rspec{
+		cfg: cfg
+	}
 }
 
 func (r Rspec) Name() string {


### PR DESCRIPTION
### Description

This PR moves the `TestRunner` interface to the detector and updates the return type of the `DetectRunner` to the interface instead of a pointer to the [Rspec struct](https://github.com/buildkite/test-splitter/blob/main/internal/runner/rspec.go#L19-L24). This will hopefully allow me to add the Jest runner (which will also implement the `TestRunner` interface more easily.

I'm wondering if there's a more ergonomic way of doing this? Also wondering if there's a neater way to handle the aforementioned Rspec struct since I'll need a Jest one that's exactly the same.

Any pointers appreciated!