### PR TITLE
Add experimental jest support

### DIFF
--- a/.buildkite/Dockerfile-compile
+++ b/.buildkite/Dockerfile-compile
@@ -1,6 +1,9 @@
-FROM ruby:3.3.4-slim-bookworm@sha256:7bb0e1e46378217ce0775845f6d64b039c56d2890bc715536e6687ab13fe2930 AS ruby
+FROM ruby:3.3.4-slim-bookworm AS ruby
+FROM node:22-bookworm-slim AS node
 
 FROM public.ecr.aws/docker/library/golang:1.23.0 AS golang
-COPY --from=ruby / /
 
-RUN gem install rspec
+COPY --from=ruby / /
+COPY --from=node / /
+
+RUN gem install rspec && npm install -g jest

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -21,6 +21,8 @@ func setEnv(t *testing.T) {
 	os.Setenv("BUILDKITE_SPLITTER_SLOW_FILE_THRESHOLD", "200")
 	os.Setenv("BUILDKITE_BUILD_ID", "123")
 	os.Setenv("BUILDKITE_STEP_ID", "456")
+	os.Setenv("BUILDKITE_SPLITTER_TEST_RUNNER", "rspec")
+	os.Setenv("BUILDKITE_SPLITTER_RESULT_PATH", "tmp/rspec.json")
 }
 
 func TestNewConfig(t *testing.T) {
@@ -40,6 +42,7 @@ func TestNewConfig(t *testing.T) {
 		TestCommand:       "bin/rspec {{testExamples}}",
 		AccessToken:       "my_token",
 		OrganizationSlug:  "my_org",
+		ResultPath:        "tmp/rspec.json",
 		SuiteSlug:         "my_suite",
 		SlowFileThreshold: 200 * time.Millisecond,
 		TestRunner:        "rspec",
@@ -62,6 +65,7 @@ func TestNewConfig_EmptyConfig(t *testing.T) {
 
 func TestNewConfig_MissingConfigWithDefault(t *testing.T) {
 	setEnv(t)
+	os.Unsetenv("BUILDKITE_SPLITTER_TEST_RUNNER")
 	os.Unsetenv("BUILDKITE_SPLITTER_MODE")
 	os.Unsetenv("BUILDKITE_SPLITTER_BASE_URL")
 	os.Unsetenv("BUILDKITE_SPLITTER_TEST_CMD")
@@ -83,6 +87,7 @@ func TestNewConfig_MissingConfigWithDefault(t *testing.T) {
 		SuiteSlug:         "my_suite",
 		SlowFileThreshold: 3 * time.Minute,
 		TestRunner:        "rspec",
+		ResultPath:        "tmp/rspec.json",
 	}
 
 	if diff := cmp.Diff(c, want); diff != "" {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -54,6 +54,10 @@ func (c *Config) validate() error {
 		errs.appendFieldError("SuiteSlug", "must not be blank")
 	}
 
+	if c.ResultPath == "" {
+		errs.appendFieldError("ResultPath", "must not be blank")
+	}
+
 	if len(errs) > 0 {
 		return errs
 	}

--- a/internal/runner/detector.go
+++ b/internal/runner/detector.go
@@ -36,7 +36,9 @@ func DetectRunner(cfg config.Config) (TestRunner, error) {
 	switch cfg.TestRunner {
 	case "rspec":
 		return NewRspec(runnerConfig), nil
+	case "jest":
+		return NewJest(runnerConfig), nil
 	default:
-		return nil, errors.New("runner value is invalid, possible values are 'rspec'")
+		return nil, errors.New("runner value is invalid, possible values are 'rspec', 'jest'")
 	}
 }

--- a/internal/runner/fixtures/jest/failure.spec.js
+++ b/internal/runner/fixtures/jest/failure.spec.js
@@ -1,0 +1,5 @@
+describe('this will fail', () => {
+  it('for sure', () => {
+    expect(1).toEqual(2)
+  })
+})

--- a/internal/runner/fixtures/jest/spells/expelliarmus.spec.js
+++ b/internal/runner/fixtures/jest/spells/expelliarmus.spec.js
@@ -1,0 +1,5 @@
+describe('expelliarmus', () => {
+  test('disarms the opponent', () => {
+    expect(1 + 1).toEqual(2)
+  })
+});

--- a/internal/runner/jest.config.js
+++ b/internal/runner/jest.config.js
@@ -1,0 +1,3 @@
+// This file is intentionally left blank.
+// Jest requires a jest.config.js file to run. It can be empty, so it doesn't
+// serve much use other than to satisfy Jest for the Jest tests.

--- a/internal/runner/jest.go
+++ b/internal/runner/jest.go
@@ -1,0 +1,196 @@
+package runner
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"slices"
+	"strings"
+
+	"github.com/buildkite/test-splitter/internal/debug"
+	"github.com/buildkite/test-splitter/internal/plan"
+	"github.com/kballard/go-shellquote"
+)
+
+var _ = TestRunner(Jest{})
+
+type Jest struct {
+	RunnerConfig
+}
+
+func NewJest(j RunnerConfig) Jest {
+	if j.TestCommand == "" {
+		j.TestCommand = "yarn test {{testExamples}} --json --testLocationInResults --outputFile {{outputFile}}"
+	}
+
+	if j.TestFilePattern == "" {
+		j.TestFilePattern = "**/{__tests__/**/*,*.spec,*.test}.{ts,js,tsx,jsx}"
+	}
+
+	if j.TestFileExcludePattern == "" {
+		j.TestFileExcludePattern = "node_modules"
+	}
+
+	if j.RetryTestCommand == "" {
+		j.RetryTestCommand = "yarn test --testNamePattern '{{testNamePattern}}' --json --testLocationInResults --outputFile {{outputFile}}"
+	}
+
+	return Jest{j}
+}
+
+func (j Jest) Name() string {
+	return "Jest"
+}
+
+// GetFiles returns an array of file names using the discovery pattern.
+func (j Jest) GetFiles() ([]string, error) {
+	debug.Println("Discovering test files with include pattern:", j.TestFilePattern, "exclude pattern:", j.TestFileExcludePattern)
+	files, err := discoverTestFiles(j.TestFilePattern, j.TestFileExcludePattern)
+	debug.Println("Discovered", len(files), "files")
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(files) == 0 {
+		return nil, fmt.Errorf("no files found with pattern %q and exclude pattern %q", j.TestFilePattern, j.TestFileExcludePattern)
+	}
+
+	return files, nil
+}
+
+func (j Jest) Run(testCases []string, retry bool) (RunResult, error) {
+	var cmd *exec.Cmd
+	var err error
+
+	defer os.Remove(j.ResultPath)
+
+	if !retry {
+		commandName, commandArgs, err := j.commandNameAndArgs(j.TestCommand, testCases)
+		if err != nil {
+			return RunResult{Status: RunStatusError}, fmt.Errorf("failed to build command: %w", err)
+		}
+
+		cmd = exec.Command(commandName, commandArgs...)
+	} else {
+		commandName, commandArgs, err := j.retryCommandNameAndArgs(j.RetryTestCommand, testCases)
+		if err != nil {
+			return RunResult{Status: RunStatusError}, fmt.Errorf("failed to build command: %w", err)
+		}
+
+		cmd = exec.Command(commandName, commandArgs...)
+	}
+
+	err = runAndForwardSignal(cmd)
+
+	if err == nil { // note: returning success early
+		return RunResult{Status: RunStatusPassed}, nil
+	}
+
+	if ProcessSignaledError := new(ProcessSignaledError); errors.As(err, &ProcessSignaledError) {
+		return RunResult{Status: RunStatusError}, err
+	}
+
+	if exitError := new(exec.ExitError); errors.As(err, &exitError) {
+		report, parseErr := j.ParseReport(j.ResultPath)
+		if parseErr != nil {
+			fmt.Println("Buildkite Test Splitter: Failed to read Jest output, tests will not be retried.")
+			return RunResult{Status: RunStatusError}, err
+		}
+
+		if report.NumFailedTests > 0 {
+			var failedTests []string
+			for _, testResult := range report.TestResults {
+				for _, example := range testResult.AssertionResults {
+					if example.Status == "failed" {
+						failedTests = append(failedTests, example.Name)
+					}
+				}
+			}
+
+			return RunResult{Status: RunStatusFailed, FailedTests: failedTests}, nil
+		}
+	}
+
+	return RunResult{Status: RunStatusError}, err
+}
+
+type JestExample struct {
+	Name   string `json:"fullName"`
+	Status string `json:"status"`
+}
+
+type JestReport struct {
+	NumFailedTests int
+	TestResults    []struct {
+		AssertionResults []JestExample
+	}
+}
+
+func (j Jest) ParseReport(path string) (JestReport, error) {
+	var report JestReport
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return JestReport{}, fmt.Errorf("failed to read Jest output: %v", err)
+	}
+
+	if err := json.Unmarshal(data, &report); err != nil {
+		return JestReport{}, fmt.Errorf("failed to parse Jest output: %s", err)
+	}
+
+	return report, nil
+}
+
+func (j Jest) commandNameAndArgs(cmd string, testCases []string) (string, []string, error) {
+	words, err := shellquote.Split(cmd)
+	if err != nil {
+		return "", []string{}, err
+	}
+	idx := slices.Index(words, "{{testExamples}}")
+	if idx < 0 {
+		words = append(words, testCases...)
+	} else {
+		words = slices.Replace(words, idx, idx+1, testCases...)
+	}
+
+	outputIdx := slices.Index(words, "{{outputFile}}")
+	if outputIdx < 0 {
+		err := fmt.Errorf("couldn't find '{{outputFile}}' sentinel in command, exiting.")
+		return "", []string{}, err
+	}
+	slices.Replace(words, outputIdx, outputIdx+1, j.ResultPath)
+
+	return words[0], words[1:], nil
+}
+
+func (j Jest) retryCommandNameAndArgs(cmd string, testCases []string) (string, []string, error) {
+	words, err := shellquote.Split(cmd)
+	if err != nil {
+		return "", []string{}, err
+	}
+
+	idx := slices.Index(words, "{{testNamePattern}}")
+	if idx < 0 {
+		err := fmt.Errorf("couldn't find '{{testNamePattern}}' sentinel in retry command")
+		return "", []string{}, err
+	}
+
+	testNamePattern := fmt.Sprintf("(%s)", strings.Join(testCases, "|"))
+
+	words = slices.Replace(words, idx, idx+1, testNamePattern)
+
+	outputIdx := slices.Index(words, "{{outputFile}}")
+	if outputIdx < 0 {
+		err := fmt.Errorf("couldn't find '{{outputFile}}' sentinel in retry command, exiting.")
+		return "", []string{}, err
+	}
+	slices.Replace(words, outputIdx, outputIdx+1, j.ResultPath)
+
+	return words[0], words[1:], err
+}
+
+func (j Jest) GetExamples(files []string) ([]plan.TestCase, error) {
+	return nil, fmt.Errorf("not supported in Jest")
+}

--- a/internal/runner/jest_test.go
+++ b/internal/runner/jest_test.go
@@ -1,0 +1,303 @@
+package runner
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"syscall"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/kballard/go-shellquote"
+)
+
+func TestNewJest(t *testing.T) {
+	cases := []struct {
+		input RunnerConfig
+		want  RunnerConfig
+	}{
+		//default
+		{
+			input: RunnerConfig{},
+			want: RunnerConfig{
+				TestCommand:            "yarn test {{testExamples}} --json --testLocationInResults --outputFile {{outputFile}}",
+				TestFilePattern:        "**/{__tests__/**/*,*.spec,*.test}.{ts,js,tsx,jsx}",
+				TestFileExcludePattern: "node_modules",
+				RetryTestCommand:       "yarn test --testNamePattern '{{testNamePattern}}' --json --testLocationInResults --outputFile {{outputFile}}",
+			},
+		},
+		// custom
+		{
+			input: RunnerConfig{
+				TestCommand:            "npx jest --json --outputFile {{outputFile}}",
+				TestFilePattern:        "spec/models/**/*.spec.js",
+				TestFileExcludePattern: "spec/features/**/*.spec.js",
+				RetryTestCommand:       "yarn test --testNamePattern '{{testNamePattern}}' --json --testLocationInResults --outputFile {{outputFile}}",
+			},
+			want: RunnerConfig{
+				TestCommand:            "npx jest --json --outputFile {{outputFile}}",
+				TestFilePattern:        "spec/models/**/*.spec.js",
+				TestFileExcludePattern: "spec/features/**/*.spec.js",
+				RetryTestCommand:       "yarn test --testNamePattern '{{testNamePattern}}' --json --testLocationInResults --outputFile {{outputFile}}",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		got := NewJest(c.input)
+		if diff := cmp.Diff(got.RunnerConfig, c.want); diff != "" {
+			t.Errorf("NewJest(%v) diff (-got +want):\n%s", c.input, diff)
+		}
+	}
+}
+
+func TestJestRun(t *testing.T) {
+	jest := NewJest(RunnerConfig{
+		TestCommand: "jest --json --outputFile {{outputFile}}",
+		ResultPath:  "jest.json",
+	})
+	files := []string{"./fixtures/jest/spells/expelliarmus.spec.js"}
+	got, err := jest.Run(files, false)
+
+	want := RunResult{
+		Status: RunStatusPassed,
+	}
+
+	if err != nil {
+		t.Errorf("Jest.Run(%q) error = %v", files, err)
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Jest.Run(%q) diff (-got +want):\n%s", files, diff)
+	}
+}
+
+func TestJestRun_Retry(t *testing.T) {
+	jest := Jest{
+		RunnerConfig{
+			TestCommand:      "jest --invalid-option --json --outputFile {{outputFile}}",
+			RetryTestCommand: "jest --testNamePattern '{{testNamePattern}}' --json --outputFile {{outputFile}}",
+		},
+	}
+	files := []string{"fixtures/jest/spells/expelliarmus.spec.js"}
+	got, err := jest.Run(files, true)
+
+	want := RunResult{
+		Status: RunStatusPassed,
+	}
+
+	if err != nil {
+		t.Errorf("Jest.Run(%q) error = %v", files, err)
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Jest.Run(%q) diff (-got +want):\n%s", files, diff)
+	}
+}
+
+func TestJestRun_TestFailed(t *testing.T) {
+	jest := NewJest(RunnerConfig{
+		TestCommand: "jest --json --outputFile {{outputFile}}",
+		ResultPath:  "jest.json",
+	})
+	files := []string{"./fixtures/jest/failure.spec.js"}
+	got, err := jest.Run(files, false)
+
+	want := RunResult{
+		Status:      RunStatusFailed,
+		FailedTests: []string{"this will fail for sure"},
+	}
+
+	if err != nil {
+		t.Errorf("Jest.Run(%q) error = %v", files, err)
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Jest.Run(%q) diff (-got +want):\n%s", files, diff)
+	}
+}
+
+func TestJestRun_CommandFailed(t *testing.T) {
+	jest := Jest{
+		RunnerConfig{
+			TestCommand: "jest --invalid-option --outputFile {{outputFile}}",
+		},
+	}
+	files := []string{}
+	got, err := jest.Run(files, false)
+
+	want := RunResult{
+		Status: RunStatusError,
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Jest.Run(%q) diff (-got +want):\n%s", files, diff)
+	}
+
+	exitError := new(exec.ExitError)
+	if !errors.As(err, &exitError) {
+		t.Errorf("Jest.Run(%q) error type = %T (%v), want *exec.ExitError", files, err, err)
+	}
+}
+
+func TestJestRun_SignaledError(t *testing.T) {
+	jest := NewJest(RunnerConfig{
+		TestCommand: "../../test/support/segv.sh --outputFile {{outputFile}}",
+	})
+	files := []string{"./doesnt-matter.spec.js"}
+
+	got, err := jest.Run(files, false)
+
+	want := RunResult{
+		Status: RunStatusError,
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Jest.Run(%q) diff (-got +want):\n%s", files, diff)
+	}
+
+	signalError := new(ProcessSignaledError)
+	if !errors.As(err, &signalError) {
+		t.Errorf("Jest.Run(%q) error type = %T (%v), want *ErrProcessSignaled", files, err, err)
+	}
+	if signalError.Signal != syscall.SIGSEGV {
+		t.Errorf("Jest.Run(%q) signal = %d, want %d", files, syscall.SIGSEGV, signalError.Signal)
+	}
+}
+
+func TestJestCommandNameAndArgs_WithInterpolationPlaceholder(t *testing.T) {
+	testCases := []string{"spec/user.spec.js", "spec/billing.spec.js"}
+	testCommand := "jest {{testExamples}} --outputFile {{outputFile}}"
+
+	jest := Jest{
+		RunnerConfig{
+			TestCommand: testCommand,
+			ResultPath:  "jest.json",
+		},
+	}
+
+	gotName, gotArgs, err := jest.commandNameAndArgs(testCommand, testCases)
+	if err != nil {
+		t.Errorf("commandNameAndArgs(%q, %q) error = %v", testCases, testCommand, err)
+	}
+
+	wantName := "jest"
+	wantArgs := []string{"spec/user.spec.js", "spec/billing.spec.js", "--outputFile", "jest.json"}
+
+	if diff := cmp.Diff(gotName, wantName); diff != "" {
+		t.Errorf("commandNameAndArgs(%q, %q) diff (-got +want):\n%s", testCases, testCommand, diff)
+	}
+	if diff := cmp.Diff(gotArgs, wantArgs); diff != "" {
+		t.Errorf("commandNameAndArgs(%q, %q) diff (-got +want):\n%s", testCases, testCommand, diff)
+	}
+}
+
+func TestJestCommandNameAndArgs_WithoutInterpolationPlaceholder(t *testing.T) {
+	testCases := []string{"spec/user.spec.js", "spec/billing.spec.js"}
+	testCommand := "jest --json --outputFile {{outputFile}}"
+
+	jest := Jest{
+		RunnerConfig{
+			TestCommand: testCommand,
+			ResultPath:  "jest.json",
+		},
+	}
+
+	gotName, gotArgs, err := jest.commandNameAndArgs(testCommand, testCases)
+	if err != nil {
+		t.Errorf("commandNameAndArgs(%q, %q) error = %v", testCases, testCommand, err)
+	}
+
+	wantName := "jest"
+	wantArgs := []string{"--json", "--outputFile", "jest.json", "spec/user.spec.js", "spec/billing.spec.js"}
+
+	if diff := cmp.Diff(gotName, wantName); diff != "" {
+		t.Errorf("commandNameAndArgs(%q, %q) diff (-got +want):\n%s", testCases, testCommand, diff)
+	}
+	if diff := cmp.Diff(gotArgs, wantArgs); diff != "" {
+		t.Errorf("commandNameAndArgs(%q, %q) diff (-got +want):\n%s", testCases, testCommand, diff)
+	}
+}
+
+func TestJestCommandNameAndArgs_InvalidTestCommand(t *testing.T) {
+	testCases := []string{"spec/user.spec.js", "spec/billing.spec.js"}
+	testCommand := "jest --options '{{testExamples}}"
+
+	jest := Jest{
+		RunnerConfig{
+			TestCommand: testCommand,
+		},
+	}
+
+	gotName, gotArgs, err := jest.commandNameAndArgs(testCommand, testCases)
+
+	wantName := ""
+	wantArgs := []string{}
+
+	if diff := cmp.Diff(gotName, wantName); diff != "" {
+		t.Errorf("commandNameAndArgs() diff (-got +want):\n%s", diff)
+	}
+	if diff := cmp.Diff(gotArgs, wantArgs); diff != "" {
+		t.Errorf("commandNameAndArgs() diff (-got +want):\n%s", diff)
+	}
+	if !errors.Is(err, shellquote.UnterminatedSingleQuoteError) {
+		t.Errorf("commandNameAndArgs() error = %v, want %v", err, shellquote.UnterminatedSingleQuoteError)
+	}
+}
+
+func TestJestRetryCommandNameAndArgs_HappyPath(t *testing.T) {
+	testCases := []string{"this will fail", "this other one will fail"}
+	retryTestCommand := "jest --testNamePattern '{{testNamePattern}}' --json --testLocationInResults --outputFile {{outputFile}}"
+
+	jest := Jest{
+		RunnerConfig{
+			RetryTestCommand: retryTestCommand,
+			ResultPath:       "jest.json",
+		},
+	}
+
+	gotName, gotArgs, err := jest.retryCommandNameAndArgs(retryTestCommand, testCases)
+	if err != nil {
+		t.Errorf("retryCommandNameAndArgs(%q, %q) error = %v", testCases, retryTestCommand, err)
+	}
+
+	wantName := "jest"
+	wantArgs := []string{"--testNamePattern", "(this will fail|this other one will fail)", "--json", "--testLocationInResults", "--outputFile", "jest.json"}
+
+	if diff := cmp.Diff(gotName, wantName); diff != "" {
+		t.Errorf("retryCommandNameAndArgs(%q, %q) diff (-got +want):\n%s", testCases, retryTestCommand, diff)
+	}
+	if diff := cmp.Diff(gotArgs, wantArgs); diff != "" {
+		t.Errorf("retryCommandNameAndArgs(%q, %q) diff (-got +want):\n%s", testCases, retryTestCommand, diff)
+	}
+}
+
+func TestJestRetryCommandNameAndArgs_WithoutInterpolationPlaceholder(t *testing.T) {
+	testCases := []string{"this will fail", "this other one will fail"}
+	retryTestCommand := "jest --json --outputFile {{outputFile}}"
+
+	jest := Jest{
+		RunnerConfig{
+			RetryTestCommand: retryTestCommand,
+			ResultPath:       "jest.json",
+		},
+	}
+
+	gotName, gotArgs, err := jest.retryCommandNameAndArgs(retryTestCommand, testCases)
+	fmt.Println(err)
+
+	wantName := ""
+	wantArgs := []string{}
+
+	if diff := cmp.Diff(gotName, wantName); diff != "" {
+		t.Errorf("retryCommandNameAndArgs() diff (-got +want):\n%s", diff)
+	}
+	if diff := cmp.Diff(gotArgs, wantArgs); diff != "" {
+		t.Errorf("retryCommandNameAndArgs() diff (-got +want):\n%s", diff)
+	}
+
+	desiredString := "couldn't find '{{testNamePattern}}' sentinel in retry command"
+	if err.Error() != desiredString {
+		t.Errorf("retryCommandNameAndArgs() error = %v, want %v", err, desiredString)
+	}
+}


### PR DESCRIPTION
### Description

The test splitter client currently only supports RSpec as a runner. This PR adds Jest support, configured by setting the `BUILDKITE_SPLITTER_RUNNER` environment variable to `jest`.

**NB** This is a first cut of Jest support, so not all features are available. SBE isn't enabled for this pass.

#169 is lined up to go in first.

### Testing

- Local testing with test-splitter-integration-testing
- RC testing on bk/bk pipeline
