### PR TITLE
Skip publishing pre-release version to Dockerhub

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -62,11 +62,13 @@ docker_manifests:
     image_templates:
       - "buildkite/test-splitter:v{{ .Version }}-amd64"
       - "buildkite/test-splitter:v{{ .Version }}-arm64"
+    # skip pushing latest tag to Dockerhub if it's a prerelease
+    skip_push: auto
   - name_template: "buildkite/test-splitter:latest"
     image_templates:
       - "buildkite/test-splitter:v{{ .Version }}-amd64"
       - "buildkite/test-splitter:v{{ .Version }}-arm64"
-    # skip pushing latest tag to Dockerhub if it's a prerelease  
+    # skip pushing latest tag to Dockerhub if it's a prerelease
     skip_push: auto
 
 nfpms:


### PR DESCRIPTION
We don't want the release pipeline to publish pre-release version to Dockerhub.