### PR TITLE
Fix up printed configuration errors.

### DIFF
--- a/internal/config/error.go
+++ b/internal/config/error.go
@@ -15,7 +15,7 @@ func (i InvalidConfigError) Error() string {
 		errs = append(errs, err.Error())
 	}
 	sort.Strings(errs)
-	return strings.Join(errs, ";\n")
+	return strings.Join(errs, "\n")
 }
 
 func (i InvalidConfigError) Unwrap() []error {

--- a/internal/config/read.go
+++ b/internal/config/read.go
@@ -63,7 +63,7 @@ func (c *Config) readFromEnv() error {
 	MaxRetries, err := getIntEnvWithDefault("BUILDKITE_SPLITTER_RETRY_COUNT", 0)
 	c.MaxRetries = MaxRetries
 	if err != nil {
-		errs.appendFieldError("MaxRetries", "was %q, must be a number", os.Getenv("BUILDKITE_SPLITTER_RETRY_COUNT"))
+		errs.appendFieldError("BUILDKITE_SPLITTER_RETRY_COUNT", "was %q, must be a number", os.Getenv("BUILDKITE_SPLITTER_RETRY_COUNT"))
 	}
 	c.RetryCommand = os.Getenv("BUILDKITE_SPLITTER_RETRY_CMD")
 
@@ -71,14 +71,14 @@ func (c *Config) readFromEnv() error {
 	parallelismInt, err := strconv.Atoi(parallelism)
 	c.Parallelism = parallelismInt
 	if err != nil {
-		errs.appendFieldError("Parallelism", "was %q, must be a number", parallelism)
+		errs.appendFieldError("BUILDKITE_PARALLEL_JOB_COUNT", "was %q, must be a number", parallelism)
 	}
 
 	nodeIndex := os.Getenv("BUILDKITE_PARALLEL_JOB")
 	nodeIndexInt, err := strconv.Atoi(nodeIndex)
 	c.NodeIndex = nodeIndexInt
 	if err != nil {
-		errs.appendFieldError("NodeIndex", "was %q, must be a number", nodeIndex)
+		errs.appendFieldError("BUILDKITE_PARALLEL_JOB", "was %q, must be a number", nodeIndex)
 	}
 
 	if len(errs) > 0 {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -9,49 +9,41 @@ func (c *Config) validate() error {
 	var errs InvalidConfigError
 
 	if c.MaxRetries < 0 {
-		errs.appendFieldError("MaxRetries", "was %d, must be greater than or equal to 0", c.MaxRetries)
-	}
-
-	if c.Identifier == "" {
-		errs.appendFieldError("Identifier", "must not be blank")
-	}
-
-	if got, limit := len(c.Identifier), 1024; got > limit {
-		errs.appendFieldError("Identifier", "was %d bytes long, must not be longer than %d", got, limit)
+		errs.appendFieldError("BUILDKITE_SPLITTER_RETRY_COUNT", "was %d, must be greater than or equal to 0", c.MaxRetries)
 	}
 
 	if got, min := c.Parallelism, 1; got < min {
-		errs.appendFieldError("Parallelism", "was %d, must be greater than or equal to %d", got, min)
+		errs.appendFieldError("BUILDKITE_PARALLEL_JOB_COUNT", "was %d, must be greater than or equal to %d", got, min)
 	}
 
 	if got, max := c.Parallelism, 1000; got > max {
-		errs.appendFieldError("Parallelism", "was %d, must not be greater than %d", got, max)
+		errs.appendFieldError("BUILDKITE_PARALLEL_JOB_COUNT", "was %d, must not be greater than %d", got, max)
 	}
 
 	if got, min := c.NodeIndex, 0; got < 0 {
-		errs.appendFieldError("NodeIndex", "was %d, must be greater than or equal to %d", got, min)
+		errs.appendFieldError("BUILDKITE_PARALLEL_JOB", "was %d, must be greater than or equal to %d", got, min)
 	}
 
 	if got, max := c.NodeIndex, c.Parallelism-1; got > max {
-		errs.appendFieldError("NodeIndex", "was %d, must not be greater than %d", got, max)
+		errs.appendFieldError("BUILDKITE_PARALLEL_JOB", "was %d, must not be greater than %d", got, max)
 	}
 
 	if c.ServerBaseUrl != "" {
 		if _, err := url.ParseRequestURI(c.ServerBaseUrl); err != nil {
-			errs.appendFieldError("ServerBaseUrl", "must be a valid URL")
+			errs.appendFieldError("BUILDKITE_SPLITTER_BASE_URL", "must be a valid URL")
 		}
 	}
 
 	if c.AccessToken == "" {
-		errs.appendFieldError("AccessToken", "must not be blank")
+		errs.appendFieldError("BUILDKITE_SPLITTER_API_ACCESS_TOKEN", "must not be blank")
 	}
 
 	if c.OrganizationSlug == "" {
-		errs.appendFieldError("OrganizationSlug", "must not be blank")
+		errs.appendFieldError("BUILDKITE_ORGANIZATION_SLUG", "must not be blank")
 	}
 
 	if c.SuiteSlug == "" {
-		errs.appendFieldError("SuiteSlug", "must not be blank")
+		errs.appendFieldError("BUILDKITE_SPLITTER_SUITE_SLUG", "must not be blank")
 	}
 
 	if c.ResultPath == "" {

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"errors"
-	"strings"
 	"testing"
 )
 
@@ -42,49 +41,39 @@ func TestConfigValidate_Invalid(t *testing.T) {
 		field string
 		value any
 	}{
+		// Base URL is bunk
 		{
-			name:  "ServerBaseUrl is not a valid url",
-			field: "ServerBaseUrl",
+			name:  "BUILDKITE_SPLITTER_BASE_URL",
 			value: "foo",
 		},
+		// Node index < 0
 		{
-			name:  "Identifier is missing",
-			field: "Identifier",
-			value: "",
-		},
-		{
-			name:  "Identifier is greater 1024 characters",
-			field: "Identifier",
-			value: strings.Repeat("a", 1025),
-		},
-		{
-			name:  "NodeIndex is less than 0",
-			field: "NodeIndex",
+			name:  "BUILDKITE_PARALLEL_JOB",
 			value: -1,
 		},
+		// Node index > parallelism
 		{
-			name:  "NodeIndex is greater than Parallelism",
-			field: "NodeIndex",
+			name:  "BUILDKITE_PARALLEL_JOB",
 			value: 15,
 		},
+		// Parallelism > 1000
 		{
-			name:  "Parallelism is greater than 1000",
-			field: "Parallelism",
+			name:  "BUILDKITE_PARALLEL_JOB_COUNT",
 			value: 1341,
 		},
+		// Organization slug is missing
 		{
-			name:  "OrganizationSlug is missing",
-			field: "OrganizationSlug",
+			name:  "BUILDKITE_ORGANIZATION_SLUG",
 			value: "",
 		},
+		// Suite slug is missing
 		{
-			name:  "SuiteSlug is missing",
-			field: "SuiteSlug",
+			name:  "BUILDKITE_SPLITTER_SUITE_SLUG",
 			value: "",
 		},
+		// API access token is blank
 		{
-			name:  "AccessToken is missing",
-			field: "AccessToken",
+			name:  "BUILDKITE_SPLITTER_API_ACCESS_TOKEN",
 			value: "",
 		},
 	}
@@ -92,20 +81,18 @@ func TestConfigValidate_Invalid(t *testing.T) {
 	for _, s := range scenario {
 		t.Run(s.name, func(t *testing.T) {
 			c := createConfig()
-			switch s.field {
-			case "ServerBaseUrl":
+			switch s.name {
+			case "BUILDKITE_SPLITTER_BASE_URL":
 				c.ServerBaseUrl = s.value.(string)
-			case "Identifier":
-				c.Identifier = s.value.(string)
-			case "NodeIndex":
+			case "BUILDKITE_PARALLEL_JOB":
 				c.NodeIndex = s.value.(int)
-			case "Parallelism":
+			case "BUILDKITE_PARALLEL_JOB_COUNT":
 				c.Parallelism = s.value.(int)
-			case "OrganizationSlug":
+			case "BUILDKITE_ORGANIZATION_SLUG":
 				c.OrganizationSlug = s.value.(string)
-			case "SuiteSlug":
+			case "BUILDKITE_SPLITTER_SUITE_SLUG":
 				c.SuiteSlug = s.value.(string)
-			case "AccessToken":
+			case "BUILDKITE_SPLITTER_API_ACCESS_TOKEN":
 				c.AccessToken = s.value.(string)
 			}
 
@@ -120,8 +107,8 @@ func TestConfigValidate_Invalid(t *testing.T) {
 				t.Errorf("config.validate() error length = %d, want 1", len(invConfigError))
 			}
 
-			if invConfigError[0].name != s.field {
-				t.Errorf("config.validate() error name = %s, want %s", invConfigError[0].name, s.field)
+			if invConfigError[0].name != s.name {
+				t.Errorf("config.validate() error name = %s, want %s", invConfigError[0].name, s.name)
 			}
 		})
 	}

--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func main() {
 	// get config
 	cfg, err := config.New()
 	if err != nil {
-		logErrorAndExit(16, "Invalid configuration: %v", err)
+		logErrorAndExit(16, "Invalid configuration...\n%v", err)
 	}
 
 	testRunner, err := runner.DetectRunner(cfg)


### PR DESCRIPTION
### Description

The test-splitter client will perform validation on a selection of the environment variables to ensure that they are in the correct format, have valid values, or are within certain bounds. If the client encounters validation errors, an error message is printed and the client will exit with status code 16.

The issue with these errors is that they refer to the members of the struct config instead of the environment variables:

<img width="891" alt="8918be43-bb34-44d2-932f-c35733fe9734" src="https://github.com/user-attachments/assets/1fbd6a26-aa86-4334-8a30-b49ba6bd3a1c">

It would be a lot easier for the user if these said BUILDKITE_SPLITTER_SUITE_SLUG must not be blank etc.

This PR changes the format for these error messages to look like this:

```
❯ ./run-splitter
Buildkite Test Splitter: Invalid configuration
BUILDKITE_PARALLEL_JOB was "", must be a number
BUILDKITE_PARALLEL_JOB was 0, must not be greater than -1
BUILDKITE_PARALLEL_JOB_COUNT was "", must be a number
BUILDKITE_PARALLEL_JOB_COUNT was 0, must be greater than or equal to 1
BUILDKITE_SPLITTER_API_ACCESS_TOKEN must not be blank
BUILDKITE_SPLITTER_SUITE_SLUG must not be blank
```