### PR TITLE
Skip pushing docker image to Dockerhub for prerelease

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,18 +37,30 @@ brews:
 dockers:
   - image_templates:
       - "packages.buildkite.com/buildkite/test-splitter-docker/test-splitter:v{{ .Version }}-amd64"
-      - "buildkite/test-splitter:v{{ .Version }}-amd64"
     dockerfile: "packaging/Dockerfile"
     build_flag_templates:
       - "--platform=linux/amd64"
   - image_templates:
       - "packages.buildkite.com/buildkite/test-splitter-docker/test-splitter:v{{ .Version }}-arm64"
-      - "buildkite/test-splitter:v{{ .Version }}-arm64"
     goarch: arm64
     dockerfile: "packaging/Dockerfile"
     build_flag_templates:
       - "--platform=linux/arm64"
-
+  - image_templates:
+      - "buildkite/test-splitter:v{{ .Version }}-amd64"
+    # skip pushing image to Dockerhub if it's a prerelease
+    skip_push: auto
+    dockerfile: "packaging/Dockerfile"
+    build_flag_templates:
+      - "--platform=linux/amd64"
+  - image_templates:
+      - "buildkite/test-splitter:v{{ .Version }}-arm64"
+    # skip pushing image to Dockerhub if it's a prerelease
+    skip_push: auto
+    goarch: arm64
+    dockerfile: "packaging/Dockerfile"
+    build_flag_templates:
+      - "--platform=linux/arm64"
 docker_manifests:
   - name_template: "packages.buildkite.com/buildkite/test-splitter-docker/test-splitter:v{{ .Version }}"
     image_templates:
@@ -62,13 +74,13 @@ docker_manifests:
     image_templates:
       - "buildkite/test-splitter:v{{ .Version }}-amd64"
       - "buildkite/test-splitter:v{{ .Version }}-arm64"
-    # skip pushing latest tag to Dockerhub if it's a prerelease
+    # skip pushing manifest to Dockerhub if it's a prerelease
     skip_push: auto
   - name_template: "buildkite/test-splitter:latest"
     image_templates:
       - "buildkite/test-splitter:v{{ .Version }}-amd64"
       - "buildkite/test-splitter:v{{ .Version }}-arm64"
-    # skip pushing latest tag to Dockerhub if it's a prerelease
+    # skip pushing manifest to Dockerhub if it's a prerelease
     skip_push: auto
 
 nfpms:


### PR DESCRIPTION
We don't want to push docker images[1] and manifests[2] to Dockerhub when releasing a pre-release version.
The manifests already skipped in the pre-release, but the individual images still being pushed to Dockerhub. This PR updates the `goreleaser` configuration to skip pushing the images to Dockerhub for pre-release.

[1] image for individual arch, e.g. `test-splitter:v0.9.0-rc.2-amd64`
[2] manifest that bundles images for each arch, e.g. `test-splitter:v0.9.0-rc.2`
