### PR TITLE
Rename {{outputFile}} to {{resultPath}}

### DIFF
--- a/internal/runner/jest.go
+++ b/internal/runner/jest.go
@@ -22,7 +22,7 @@ type Jest struct {
 
 func NewJest(j RunnerConfig) Jest {
 	if j.TestCommand == "" {
-		j.TestCommand = "yarn test {{testExamples}} --json --testLocationInResults --outputFile {{outputFile}}"
+		j.TestCommand = "yarn test {{testExamples}} --json --testLocationInResults --outputFile {{resultPath}}"
 	}
 
 	if j.TestFilePattern == "" {
@@ -34,7 +34,7 @@ func NewJest(j RunnerConfig) Jest {
 	}
 
 	if j.RetryTestCommand == "" {
-		j.RetryTestCommand = "yarn test --testNamePattern '{{testNamePattern}}' --json --testLocationInResults --outputFile {{outputFile}}"
+		j.RetryTestCommand = "yarn test --testNamePattern '{{testNamePattern}}' --json --testLocationInResults --outputFile {{resultPath}}"
 	}
 
 	return Jest{j}
@@ -155,9 +155,9 @@ func (j Jest) commandNameAndArgs(cmd string, testCases []string) (string, []stri
 		words = slices.Replace(words, idx, idx+1, testCases...)
 	}
 
-	outputIdx := slices.Index(words, "{{outputFile}}")
+	outputIdx := slices.Index(words, "{{resultPath}}")
 	if outputIdx < 0 {
-		err := fmt.Errorf("couldn't find '{{outputFile}}' sentinel in command, exiting.")
+		err := fmt.Errorf("couldn't find '{{resultPath}}' sentinel in command, exiting.")
 		return "", []string{}, err
 	}
 	slices.Replace(words, outputIdx, outputIdx+1, j.ResultPath)
@@ -181,9 +181,9 @@ func (j Jest) retryCommandNameAndArgs(cmd string, testCases []string) (string, [
 
 	words = slices.Replace(words, idx, idx+1, testNamePattern)
 
-	outputIdx := slices.Index(words, "{{outputFile}}")
+	outputIdx := slices.Index(words, "{{resultPath}}")
 	if outputIdx < 0 {
-		err := fmt.Errorf("couldn't find '{{outputFile}}' sentinel in retry command, exiting.")
+		err := fmt.Errorf("couldn't find '{{resultPath}}' sentinel in retry command, exiting.")
 		return "", []string{}, err
 	}
 	slices.Replace(words, outputIdx, outputIdx+1, j.ResultPath)

--- a/internal/runner/jest_test.go
+++ b/internal/runner/jest_test.go
@@ -20,25 +20,25 @@ func TestNewJest(t *testing.T) {
 		{
 			input: RunnerConfig{},
 			want: RunnerConfig{
-				TestCommand:            "yarn test {{testExamples}} --json --testLocationInResults --outputFile {{outputFile}}",
+				TestCommand:            "yarn test {{testExamples}} --json --testLocationInResults --outputFile {{resultPath}}",
 				TestFilePattern:        "**/{__tests__/**/*,*.spec,*.test}.{ts,js,tsx,jsx}",
 				TestFileExcludePattern: "node_modules",
-				RetryTestCommand:       "yarn test --testNamePattern '{{testNamePattern}}' --json --testLocationInResults --outputFile {{outputFile}}",
+				RetryTestCommand:       "yarn test --testNamePattern '{{testNamePattern}}' --json --testLocationInResults --outputFile {{resultPath}}",
 			},
 		},
 		// custom
 		{
 			input: RunnerConfig{
-				TestCommand:            "npx jest --json --outputFile {{outputFile}}",
+				TestCommand:            "npx jest --json --outputFile {{resultPath}}",
 				TestFilePattern:        "spec/models/**/*.spec.js",
 				TestFileExcludePattern: "spec/features/**/*.spec.js",
-				RetryTestCommand:       "yarn test --testNamePattern '{{testNamePattern}}' --json --testLocationInResults --outputFile {{outputFile}}",
+				RetryTestCommand:       "yarn test --testNamePattern '{{testNamePattern}}' --json --testLocationInResults --outputFile {{resultPath}}",
 			},
 			want: RunnerConfig{
-				TestCommand:            "npx jest --json --outputFile {{outputFile}}",
+				TestCommand:            "npx jest --json --outputFile {{resultPath}}",
 				TestFilePattern:        "spec/models/**/*.spec.js",
 				TestFileExcludePattern: "spec/features/**/*.spec.js",
-				RetryTestCommand:       "yarn test --testNamePattern '{{testNamePattern}}' --json --testLocationInResults --outputFile {{outputFile}}",
+				RetryTestCommand:       "yarn test --testNamePattern '{{testNamePattern}}' --json --testLocationInResults --outputFile {{resultPath}}",
 			},
 		},
 	}
@@ -53,7 +53,7 @@ func TestNewJest(t *testing.T) {
 
 func TestJestRun(t *testing.T) {
 	jest := NewJest(RunnerConfig{
-		TestCommand: "jest --json --outputFile {{outputFile}}",
+		TestCommand: "jest --json --outputFile {{resultPath}}",
 		ResultPath:  "jest.json",
 	})
 	files := []string{"./fixtures/jest/spells/expelliarmus.spec.js"}
@@ -75,8 +75,8 @@ func TestJestRun(t *testing.T) {
 func TestJestRun_Retry(t *testing.T) {
 	jest := Jest{
 		RunnerConfig{
-			TestCommand:      "jest --invalid-option --json --outputFile {{outputFile}}",
-			RetryTestCommand: "jest --testNamePattern '{{testNamePattern}}' --json --outputFile {{outputFile}}",
+			TestCommand:      "jest --invalid-option --json --outputFile {{resultPath}}",
+			RetryTestCommand: "jest --testNamePattern '{{testNamePattern}}' --json --outputFile {{resultPath}}",
 		},
 	}
 	files := []string{"fixtures/jest/spells/expelliarmus.spec.js"}
@@ -97,7 +97,7 @@ func TestJestRun_Retry(t *testing.T) {
 
 func TestJestRun_TestFailed(t *testing.T) {
 	jest := NewJest(RunnerConfig{
-		TestCommand: "jest --json --outputFile {{outputFile}}",
+		TestCommand: "jest --json --outputFile {{resultPath}}",
 		ResultPath:  "jest.json",
 	})
 	files := []string{"./fixtures/jest/failure.spec.js"}
@@ -120,7 +120,7 @@ func TestJestRun_TestFailed(t *testing.T) {
 func TestJestRun_CommandFailed(t *testing.T) {
 	jest := Jest{
 		RunnerConfig{
-			TestCommand: "jest --invalid-option --outputFile {{outputFile}}",
+			TestCommand: "jest --invalid-option --outputFile {{resultPath}}",
 		},
 	}
 	files := []string{}
@@ -142,7 +142,7 @@ func TestJestRun_CommandFailed(t *testing.T) {
 
 func TestJestRun_SignaledError(t *testing.T) {
 	jest := NewJest(RunnerConfig{
-		TestCommand: "../../test/support/segv.sh --outputFile {{outputFile}}",
+		TestCommand: "../../test/support/segv.sh --outputFile {{resultPath}}",
 	})
 	files := []string{"./doesnt-matter.spec.js"}
 
@@ -167,7 +167,7 @@ func TestJestRun_SignaledError(t *testing.T) {
 
 func TestJestCommandNameAndArgs_WithInterpolationPlaceholder(t *testing.T) {
 	testCases := []string{"spec/user.spec.js", "spec/billing.spec.js"}
-	testCommand := "jest {{testExamples}} --outputFile {{outputFile}}"
+	testCommand := "jest {{testExamples}} --outputFile {{resultPath}}"
 
 	jest := Jest{
 		RunnerConfig{
@@ -194,7 +194,7 @@ func TestJestCommandNameAndArgs_WithInterpolationPlaceholder(t *testing.T) {
 
 func TestJestCommandNameAndArgs_WithoutInterpolationPlaceholder(t *testing.T) {
 	testCases := []string{"spec/user.spec.js", "spec/billing.spec.js"}
-	testCommand := "jest --json --outputFile {{outputFile}}"
+	testCommand := "jest --json --outputFile {{resultPath}}"
 
 	jest := Jest{
 		RunnerConfig{
@@ -247,7 +247,7 @@ func TestJestCommandNameAndArgs_InvalidTestCommand(t *testing.T) {
 
 func TestJestRetryCommandNameAndArgs_HappyPath(t *testing.T) {
 	testCases := []string{"this will fail", "this other one will fail"}
-	retryTestCommand := "jest --testNamePattern '{{testNamePattern}}' --json --testLocationInResults --outputFile {{outputFile}}"
+	retryTestCommand := "jest --testNamePattern '{{testNamePattern}}' --json --testLocationInResults --outputFile {{resultPath}}"
 
 	jest := Jest{
 		RunnerConfig{
@@ -274,7 +274,7 @@ func TestJestRetryCommandNameAndArgs_HappyPath(t *testing.T) {
 
 func TestJestRetryCommandNameAndArgs_WithoutInterpolationPlaceholder(t *testing.T) {
 	testCases := []string{"this will fail", "this other one will fail"}
-	retryTestCommand := "jest --json --outputFile {{outputFile}}"
+	retryTestCommand := "jest --json --outputFile {{resultPath}}"
 
 	jest := Jest{
 		RunnerConfig{


### PR DESCRIPTION
### Description

To simplify things a little bit, we should rename the outputFile interpolation sentinel to resultPath, to match the environment variable name more closely.