### PR TITLE
Append --format progress to Rspec dry run every time

### DIFF
--- a/internal/runner/rspec.go
+++ b/internal/runner/rspec.go
@@ -202,10 +202,9 @@ func (r Rspec) GetExamples(files []string) ([]plan.TestCase, error) {
 
 	cmdArgs = append(cmdArgs, "--dry-run", "--format", "json", "--out", f.Name(), "--format", "progress")
 
-	debug.Println("Running `rspec --dry-run`")
+	debug.Printf("Running `%s %s` for dry run", cmdName, strings.Join(cmdArgs, " "))
 
 	output, err := exec.Command(cmdName, cmdArgs...).CombinedOutput()
-	debug.Println(string(output))
 
 	if err != nil {
 		return []plan.TestCase{}, fmt.Errorf("failed to run rspec dry run: %s", output)

--- a/internal/runner/rspec.go
+++ b/internal/runner/rspec.go
@@ -200,10 +200,7 @@ func (r Rspec) GetExamples(files []string) ([]plan.TestCase, error) {
 		return nil, err
 	}
 
-	cmdArgs = append(cmdArgs, "--dry-run", "--format", "json", "--out", f.Name())
-	if debug.Enabled {
-		cmdArgs = append(cmdArgs, "--format", "progress")
-	}
+	cmdArgs = append(cmdArgs, "--dry-run", "--format", "json", "--out", f.Name(), "--format", "progress")
 
 	debug.Println("Running `rspec --dry-run`")
 


### PR DESCRIPTION
We append `--format progress` to Rspec dry run when getting examples only when debug mode is enabled. To provide more information to the customer when there is a failure during the dry run, we need to append `--format progress` to the command regardless of the debug mode status.