### PR TITLE
Test splitter exits early if either STEP_ID or BUILD_ID are blank.

### DIFF
--- a/internal/config/read.go
+++ b/internal/config/read.go
@@ -37,7 +37,18 @@ func (c *Config) readFromEnv() error {
 	c.OrganizationSlug = os.Getenv("BUILDKITE_ORGANIZATION_SLUG")
 	c.SuiteSlug = os.Getenv("BUILDKITE_SPLITTER_SUITE_SLUG")
 
-	c.Identifier = fmt.Sprintf("%s/%s", os.Getenv("BUILDKITE_BUILD_ID"), os.Getenv("BUILDKITE_STEP_ID"))
+	buildId := os.Getenv("BUILDKITE_BUILD_ID")
+	if buildId == "" {
+		errs.appendFieldError("BUILDKITE_BUILD_ID", "must not be blank")
+	}
+
+	stepId := os.Getenv("BUILDKITE_STEP_ID")
+	if stepId == "" {
+		errs.appendFieldError("BUILDKITE_STEP_ID", "must not be blank")
+	}
+
+	c.Identifier = fmt.Sprintf("%s/%s", buildId, stepId)
+
 	c.ServerBaseUrl = getEnvWithDefault("BUILDKITE_SPLITTER_BASE_URL", "https://api.buildkite.com")
 	c.TestCommand = os.Getenv("BUILDKITE_SPLITTER_TEST_CMD")
 	c.TestFilePattern = os.Getenv("BUILDKITE_SPLITTER_TEST_FILE_PATTERN")

--- a/internal/config/read_test.go
+++ b/internal/config/read_test.go
@@ -98,3 +98,45 @@ func TestConfigReadFromEnv_NotInteger(t *testing.T) {
 		t.Errorf("config.readFromEnv() error length = %d, want 2", len(invConfigError))
 	}
 }
+
+func TestConfigReadFromEnv_MissingBuildId(t *testing.T) {
+	os.Setenv("BUILDKITE_SPLITTER_BASE_URL", "")
+	os.Setenv("BUILDKITE_SPLITTER_MODE", "")
+	os.Setenv("BUILDKITE_SPLITTER_TEST_CMD", "")
+	os.Setenv("BUILDKITE_SPLITTER_RETRY_COUNT", "")
+	os.Setenv("BUILDKITE_STEP_ID", "123")
+	defer os.Clearenv()
+
+	c := Config{}
+	err := c.readFromEnv()
+
+	var invConfigError InvalidConfigError
+	want := "BUILDKITE_BUILD_ID must not be blank"
+
+	if errors.As(err, &invConfigError) {
+		if got := invConfigError[0].Error(); got != want {
+			t.Errorf("config.readFromEnv() got = %v, want = %v", got, want)
+		}
+	}
+}
+
+func TestConfigReadFromEnv_MissingStepId(t *testing.T) {
+	os.Setenv("BUILDKITE_SPLITTER_BASE_URL", "")
+	os.Setenv("BUILDKITE_SPLITTER_MODE", "")
+	os.Setenv("BUILDKITE_SPLITTER_TEST_CMD", "")
+	os.Setenv("BUILDKITE_SPLITTER_RETRY_COUNT", "")
+	os.Setenv("BUILDKITE_BUILD_ID", "123")
+	defer os.Clearenv()
+
+	c := Config{}
+	err := c.readFromEnv()
+
+	var invConfigError InvalidConfigError
+	want := "BUILDKITE_STEP_ID must not be blank"
+
+	if errors.As(err, &invConfigError) {
+		if got := invConfigError[0].Error(); got != want {
+			t.Errorf("config.readFromEnv() got = %v, want = %v", got, want)
+		}
+	}
+}

--- a/internal/config/read_test.go
+++ b/internal/config/read_test.go
@@ -116,6 +116,10 @@ func TestConfigReadFromEnv_MissingBuildId(t *testing.T) {
 	err := c.readFromEnv()
 
 	var invConfigError InvalidConfigError
+	if !errors.As(err, &invConfigError) {
+		t.Errorf("config.readFromEnv() error = %v, want InvalidConfigError", err)
+	}
+
 	want := "BUILDKITE_BUILD_ID must not be blank"
 
 	if errors.As(err, &invConfigError) {
@@ -137,6 +141,10 @@ func TestConfigReadFromEnv_MissingStepId(t *testing.T) {
 	err := c.readFromEnv()
 
 	var invConfigError InvalidConfigError
+	if !errors.As(err, &invConfigError) {
+		t.Errorf("config.readFromEnv() error = %v, want InvalidConfigError", err)
+	}
+
 	want := "BUILDKITE_STEP_ID must not be blank"
 
 	if errors.As(err, &invConfigError) {

--- a/internal/config/read_test.go
+++ b/internal/config/read_test.go
@@ -81,8 +81,12 @@ func TestConfigReadFromEnv_MissingConfigWithDefault(t *testing.T) {
 }
 
 func TestConfigReadFromEnv_NotInteger(t *testing.T) {
+	os.Setenv("BUILDKITE_BUILD_ID", "abc")
+	os.Setenv("BUILDKITE_STEP_ID", "123")
 	os.Setenv("BUILDKITE_PARALLEL_JOB_COUNT", "foo")
 	os.Setenv("BUILDKITE_PARALLEL_JOB", "bar")
+	defer os.Unsetenv("BUILDKITE_BUILD_ID")
+	defer os.Unsetenv("BUILDKITE_STEP_ID")
 	defer os.Unsetenv("BUILDKITE_PARALLEL_JOB_COUNT")
 	defer os.Unsetenv("BUILDKITE_PARALLEL_JOB")
 
@@ -95,6 +99,7 @@ func TestConfigReadFromEnv_NotInteger(t *testing.T) {
 	}
 
 	if len(invConfigError) != 2 {
+		t.Errorf("%v", invConfigError)
 		t.Errorf("config.readFromEnv() error length = %d, want 2", len(invConfigError))
 	}
 }

--- a/internal/config/read_test.go
+++ b/internal/config/read_test.go
@@ -122,10 +122,8 @@ func TestConfigReadFromEnv_MissingBuildId(t *testing.T) {
 
 	want := "BUILDKITE_BUILD_ID must not be blank"
 
-	if errors.As(err, &invConfigError) {
-		if got := invConfigError[0].Error(); got != want {
-			t.Errorf("config.readFromEnv() got = %v, want = %v", got, want)
-		}
+	if got := invConfigError[0].Error(); got != want {
+		t.Errorf("config.readFromEnv() got = %v, want = %v", got, want)
 	}
 }
 


### PR DESCRIPTION
### Description

Since 0.7.0, the test splitter has constructed the identifier internally. However, the validation was never changed to ensure that _both_ the BUILD_ID and STEP_ID are present in the environment to generate the identifier correctly.

This PR updates the test splitter so that it will exit with a configuration error (status 16) if either the BUILDKITE_BUILD_ID or BUILDKITE_STEP_ID environment variables are blank.