### PR TITLE
Keep Jest result after each run

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ In addition to the above variables, you must set the following environment varia
 | -------------------- | ----------- |
 | `BUILDKITE_SPLITTER_API_ACCESS_TOKEN ` | Buildkite API access token with `read_suites`, `read_test_plan`, and `write_test_plan` scopes. You can create an access token from [Personal Settings](https://buildkite.com/user/api-access-tokens) in Buildkite |
 | `BUILDKITE_SPLITTER_SUITE_SLUG` | The slug of your Buildkite Test Analytics test suite. You can find the suite slug in the url for your suite. For example, the slug for the url: https://buildkite.com/organizations/my-organization/analytics/suites/my-suite is `my-suite` |
-
-| `BUILDKITE_SPLITTER_RESULT_PATH` | Test Splitter uses the result path environment variable to tell the runner where to store test result summaries, for use in retries and verification. For RSpec, this would usually be set to `tmp/rspec.json`, while for Jest, this would usually be set to `tmp/jest.json`. |
+| `BUILDKITE_SPLITTER_RESULT_PATH` | Test Splitter uses this environment variable to tell the runner where to store the test result. Test Splitter reads the test result after each test run for retries and verification. For RSpec, the result is generated using the `--format json` and `--out` CLI options, while for Jest, it is generated using the `--json` and `--outputFile` options. We have included these options in the default test command for RSpec and Jest. If you need to customize your test command, make sure to append the CLI options to save the result to a file. Please refer to the `BUILDKITE_SPLITTER_TEST_CMD` environment variable for more details. <br> *Note: Test Splitter will not delete the file after running the test, however it will be deleted by Buildkite Agent as part of build lifecycle. *|
 
 
 <br>

--- a/internal/runner/jest.go
+++ b/internal/runner/jest.go
@@ -65,8 +65,6 @@ func (j Jest) Run(testCases []string, retry bool) (RunResult, error) {
 	var cmd *exec.Cmd
 	var err error
 
-	defer os.Remove(j.ResultPath)
-
 	if !retry {
 		commandName, commandArgs, err := j.commandNameAndArgs(j.TestCommand, testCases)
 		if err != nil {

--- a/internal/runner/jest_test.go
+++ b/internal/runner/jest_test.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"syscall"
 	"testing"
@@ -56,6 +57,11 @@ func TestJestRun(t *testing.T) {
 		TestCommand: "jest --json --outputFile {{resultPath}}",
 		ResultPath:  "jest.json",
 	})
+
+	t.Cleanup(func() {
+		os.Remove(jest.ResultPath)
+	})
+
 	files := []string{"./fixtures/jest/spells/expelliarmus.spec.js"}
 	got, err := jest.Run(files, false)
 
@@ -79,6 +85,11 @@ func TestJestRun_Retry(t *testing.T) {
 			RetryTestCommand: "jest --testNamePattern '{{testNamePattern}}' --json --outputFile {{resultPath}}",
 		},
 	}
+
+	t.Cleanup(func() {
+		os.Remove(jest.ResultPath)
+	})
+
 	files := []string{"fixtures/jest/spells/expelliarmus.spec.js"}
 	got, err := jest.Run(files, true)
 
@@ -100,6 +111,11 @@ func TestJestRun_TestFailed(t *testing.T) {
 		TestCommand: "jest --json --outputFile {{resultPath}}",
 		ResultPath:  "jest.json",
 	})
+
+	t.Cleanup(func() {
+		os.Remove(jest.ResultPath)
+	})
+
 	files := []string{"./fixtures/jest/failure.spec.js"}
 	got, err := jest.Run(files, false)
 
@@ -123,6 +139,11 @@ func TestJestRun_CommandFailed(t *testing.T) {
 			TestCommand: "jest --invalid-option --outputFile {{resultPath}}",
 		},
 	}
+
+	t.Cleanup(func() {
+		os.Remove(jest.ResultPath)
+	})
+
 	files := []string{}
 	got, err := jest.Run(files, false)
 


### PR DESCRIPTION
### Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->
Jest doesn't support saving JSON output to multiple file at the same time. Because we currently delete the JSON file after each Jest run, the customer cannot access the file for other purposes. Therefore, we need to keep the JSON file after each run. This is also consistent with the Rspec behaviour.

There is a concern about Test Splitter saving a lot of files at the agent machine, however, Buildkite Agent will clean up the working directory as part of its lifecycle, so this should not be a problem.