### PR TITLE
Filter tests regardless split by example on or off

### DIFF
--- a/internal/api/filter_tests.go
+++ b/internal/api/filter_tests.go
@@ -14,8 +14,7 @@ type FilterTestsParams struct {
 }
 
 type FilteredTest struct {
-	Path   string `json:"path"`
-	Reason string `json:"reason"`
+	Path string `json:"path"`
 }
 
 type filteredTestResponse struct {

--- a/internal/api/filter_tests_test.go
+++ b/internal/api/filter_tests_test.go
@@ -55,8 +55,7 @@ func TestFilterTests_SlowFiles(t *testing.T) {
 			b.Header("Content-Type", matchers.Like("application/json; charset=utf-8"))
 			b.JSONBody(matchers.MapMatcher{
 				"tests": matchers.EachLike(matchers.MapMatcher{
-					"path":   matchers.Like("./turtle_spec.rb"),
-					"reason": matchers.Like("slow_files"),
+					"path": matchers.Like("./turtle_spec.rb"),
 				}, 1),
 			})
 		}).
@@ -73,8 +72,7 @@ func TestFilterTests_SlowFiles(t *testing.T) {
 			}
 			want := []FilteredTest{
 				{
-					Path:   "./turtle_spec.rb",
-					Reason: "slow_files",
+					Path: "./turtle_spec.rb",
 				},
 			}
 

--- a/main.go
+++ b/main.go
@@ -271,6 +271,10 @@ func createRequestParam(ctx context.Context, cfg config.Config, files []string, 
 		})
 	}
 
+	if cfg.SplitByExample {
+		debug.Println("Splitting by example")
+	}
+
 	debug.Printf("Filtering %d files", len(files))
 	filteredFiles, err := client.FilterTests(ctx, cfg.SuiteSlug, api.FilterTestsParams{
 		Files: testFiles,

--- a/main.go
+++ b/main.go
@@ -271,20 +271,6 @@ func createRequestParam(ctx context.Context, cfg config.Config, files []string, 
 		})
 	}
 
-	if !cfg.SplitByExample {
-		debug.Println("Splitting by file")
-		return api.TestPlanParams{
-			Identifier:  cfg.Identifier,
-			Parallelism: cfg.Parallelism,
-			Branch:      cfg.Branch,
-			Tests: api.TestPlanParamsTest{
-				Files: testFiles,
-			},
-		}, nil
-	}
-
-	debug.Println("Splitting by example")
-
 	debug.Printf("Filtering %d files", len(files))
 	filteredFiles, err := client.FilterTests(ctx, cfg.SuiteSlug, api.FilterTestsParams{
 		Files: testFiles,

--- a/main_test.go
+++ b/main_test.go
@@ -420,39 +420,7 @@ func TestFetchOrCreateTestPlan_BadRequest(t *testing.T) {
 	}
 }
 
-func TestCreateRequestParams_SplitByFile(t *testing.T) {
-	cfg := config.Config{
-		OrganizationSlug: "my-org",
-		SuiteSlug:        "my-suite",
-		Identifier:       "identifier",
-		Parallelism:      7,
-		Branch:           "",
-	}
-
-	client := api.NewClient(api.ClientConfig{})
-	got, err := createRequestParam(context.Background(), cfg, []string{"apple", "banana"}, *client, runner.Rspec{})
-	want := api.TestPlanParams{
-		Identifier:  "identifier",
-		Parallelism: 7,
-		Branch:      "",
-		Tests: api.TestPlanParamsTest{
-			Files: []plan.TestCase{
-				{Path: "apple"},
-				{Path: "banana"},
-			},
-		},
-	}
-
-	if err != nil {
-		t.Errorf("createRequestParam() error = %v", err)
-	}
-
-	if diff := cmp.Diff(got, want); diff != "" {
-		t.Errorf("createRequestParam() diff (-got +want):\n%s", diff)
-	}
-}
-
-func TestCreateRequestParams_SplitByExample(t *testing.T) {
+func TestCreateRequestParams(t *testing.T) {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, `
 {
@@ -470,7 +438,6 @@ func TestCreateRequestParams_SplitByExample(t *testing.T) {
 		Identifier:       "identifier",
 		Parallelism:      7,
 		Branch:           "",
-		SplitByExample:   true,
 	}
 
 	client := api.NewClient(api.ClientConfig{
@@ -538,7 +505,7 @@ func TestCreateRequestParams_SplitByExample(t *testing.T) {
 	}
 }
 
-func TestCreateRequestParams_SplitByExample_FilterTestsError(t *testing.T) {
+func TestCreateRequestParams_FilterTestsError(t *testing.T) {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{ "message": "forbidden" }`, http.StatusForbidden)
 	}))
@@ -574,7 +541,7 @@ func TestCreateRequestParams_SplitByExample_FilterTestsError(t *testing.T) {
 	}
 }
 
-func TestCreateRequestParams_SplitByExample_NoFilteredFiles(t *testing.T) {
+func TestCreateRequestParams_NoFilteredFiles(t *testing.T) {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, `
 {


### PR DESCRIPTION
### Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->
To support test quarantining, we need to filter tests on the server side regardless whether split by example is on or off. With this changes, and some changes on the server side, test splitter will be able split files that has quarantined tests, without having to enable the Split by Example. Splitting slow files will only be done when Split by Example feature is on.
