### PR TITLE
Update node index and parallelism validation logic

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,11 +11,11 @@ type Config struct {
 	// RetryCommand is the command to run the retry tests.
 	RetryCommand string
 	// Node index is index of the current node.
-	NodeIndex int
+	NodeIndex *int
 	// OrganizationSlug is the slug of the organization.
 	OrganizationSlug string
 	// Parallelism is the number of parallel tasks to run.
-	Parallelism int
+	Parallelism *int
 	// The path to the result file.
 	ResultPath string
 	// ServerBaseUrl is the base URL of the test splitter server.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,7 +35,7 @@ type Config struct {
 	TestRunner string
 	// Branch is the string value of the git branch name, used by Buildkite only.
 	Branch string
-
+	// errs is a map of environment variables name and the validation errors associated with them.
 	errs InvalidConfigError
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 // Config is the internal representation of the complete test splitter client configuration.
+
 type Config struct {
 	// AccessToken is the access token for the API.
 	AccessToken string
@@ -11,11 +12,11 @@ type Config struct {
 	// RetryCommand is the command to run the retry tests.
 	RetryCommand string
 	// Node index is index of the current node.
-	NodeIndex *int
+	NodeIndex int
 	// OrganizationSlug is the slug of the organization.
 	OrganizationSlug string
 	// Parallelism is the number of parallel tasks to run.
-	Parallelism *int
+	Parallelism int
 	// The path to the result file.
 	ResultPath string
 	// ServerBaseUrl is the base URL of the test splitter server.
@@ -34,25 +35,19 @@ type Config struct {
 	TestRunner string
 	// Branch is the string value of the git branch name, used by Buildkite only.
 	Branch string
+
+	errs InvalidConfigError
 }
 
 // New wraps the readFromEnv and validate functions to create a new Config struct.
 // It returns Config struct and an InvalidConfigError if there is an invalid configuration.
 func New() (Config, error) {
-	var errs InvalidConfigError
+	c := Config{errs: InvalidConfigError{}}
+	c.readFromEnv()
+	c.validate()
 
-	c := Config{}
-
-	if err := c.readFromEnv(); err != nil {
-		errs = append(errs, err.(InvalidConfigError)...)
-	}
-
-	if err := c.validate(); err != nil {
-		errs = append(errs, err.(InvalidConfigError)...)
-	}
-
-	if len(errs) > 0 {
-		return Config{}, errs
+	if len(c.errs) > 0 {
+		return Config{}, c.errs
 	}
 
 	return c, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func setEnv(t *testing.T) {
@@ -43,9 +44,10 @@ func TestNewConfig(t *testing.T) {
 		ResultPath:       "tmp/rspec.json",
 		SuiteSlug:        "my_suite",
 		TestRunner:       "rspec",
+		errs:             InvalidConfigError{},
 	}
 
-	if diff := cmp.Diff(c, want); diff != "" {
+	if diff := cmp.Diff(c, want, cmpopts.IgnoreUnexported(Config{})); diff != "" {
 		t.Errorf("config.New() diff (-got +want):\n%s", diff)
 	}
 }
@@ -85,7 +87,7 @@ func TestNewConfig_MissingConfigWithDefault(t *testing.T) {
 		ResultPath:       "tmp/rspec.json",
 	}
 
-	if diff := cmp.Diff(c, want); diff != "" {
+	if diff := cmp.Diff(c, want, cmpopts.IgnoreUnexported(Config{})); diff != "" {
 		t.Errorf("config.New() diff (-got +want):\n%s", diff)
 	}
 }

--- a/internal/config/error.go
+++ b/internal/config/error.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-// InvalidConfigError is an error that contains a list of all invalid fields in the config.
+// InvalidConfigError is an error that contains a map of all validation errors on each field of the configuration.
 type InvalidConfigError map[string][]error
 
 func (i InvalidConfigError) Error() string {
@@ -18,16 +18,6 @@ func (i InvalidConfigError) Error() string {
 	}
 	sort.Strings(errs)
 	return strings.Join(errs, "\n")
-}
-
-func (i InvalidConfigError) Unwrap() []error {
-	errs := make([]error, 0, len(i))
-	for field, value := range i {
-		for _, v := range value {
-			errs = append(errs, fmt.Errorf("%s %s", field, v))
-		}
-	}
-	return errs
 }
 
 func (e InvalidConfigError) appendFieldError(field, format string, v ...any) {

--- a/internal/config/read.go
+++ b/internal/config/read.go
@@ -69,16 +69,14 @@ func (c *Config) readFromEnv() error {
 
 	parallelism := os.Getenv("BUILDKITE_PARALLEL_JOB_COUNT")
 	parallelismInt, err := strconv.Atoi(parallelism)
-	c.Parallelism = parallelismInt
-	if err != nil {
-		errs.appendFieldError("BUILDKITE_PARALLEL_JOB_COUNT", "was %q, must be a number", parallelism)
+	if err == nil {
+		c.Parallelism = &parallelismInt
 	}
 
 	nodeIndex := os.Getenv("BUILDKITE_PARALLEL_JOB")
 	nodeIndexInt, err := strconv.Atoi(nodeIndex)
-	c.NodeIndex = nodeIndexInt
-	if err != nil {
-		errs.appendFieldError("BUILDKITE_PARALLEL_JOB", "was %q, must be a number", nodeIndex)
+	if err == nil {
+		c.NodeIndex = &nodeIndexInt
 	}
 
 	if len(errs) > 0 {

--- a/internal/config/read_test.go
+++ b/internal/config/read_test.go
@@ -156,10 +156,6 @@ func TestConfigReadFromEnv_MissingStepId(t *testing.T) {
 }
 
 func TestConfigReadFromEnv_InvalidParallelJob(t *testing.T) {
-	os.Setenv("BUILDKITE_SPLITTER_BASE_URL", "")
-	os.Setenv("BUILDKITE_SPLITTER_MODE", "")
-	os.Setenv("BUILDKITE_SPLITTER_TEST_CMD", "")
-	os.Setenv("BUILDKITE_SPLITTER_RETRY_COUNT", "")
 	os.Setenv("BUILDKITE_BUILD_ID", "123")
 	os.Setenv("BUILDKITE_STEP_ID", "456")
 	os.Setenv("BUILDKITE_PARALLEL_JOB", "")
@@ -182,10 +178,6 @@ func TestConfigReadFromEnv_InvalidParallelJob(t *testing.T) {
 }
 
 func TestConfigReadFromEnv_InvalidParallelJobCount(t *testing.T) {
-	os.Setenv("BUILDKITE_SPLITTER_BASE_URL", "")
-	os.Setenv("BUILDKITE_SPLITTER_MODE", "")
-	os.Setenv("BUILDKITE_SPLITTER_TEST_CMD", "")
-	os.Setenv("BUILDKITE_SPLITTER_RETRY_COUNT", "")
 	os.Setenv("BUILDKITE_BUILD_ID", "123")
 	os.Setenv("BUILDKITE_STEP_ID", "456")
 	os.Setenv("BUILDKITE_PARALLEL_JOB", "10")

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -21,13 +21,15 @@ func (c *Config) validate() error {
 		}
 	}
 
-	if c.errs["BUILDKITE_PARALLEL_JOB"] == nil && c.errs["BUILDKITE_PARALLEL_JOB_COUNT"] == nil {
+	if c.errs["BUILDKITE_PARALLEL_JOB"] == nil {
 		if got, min := c.NodeIndex, 0; got < 0 {
 			c.errs.appendFieldError("BUILDKITE_PARALLEL_JOB", "was %d, must be greater than or equal to %d", got, min)
 		}
 
-		if got, max := c.NodeIndex, c.Parallelism-1; got > max {
-			c.errs.appendFieldError("BUILDKITE_PARALLEL_JOB", "was %d, must not be greater than %d", got, max)
+		if c.errs["BUILDKITE_PARALLEL_JOB_COUNT"] == nil {
+			if got, max := c.NodeIndex, c.Parallelism-1; got > max {
+				c.errs.appendFieldError("BUILDKITE_PARALLEL_JOB", "was %d, must not be greater than %d", got, max)
+			}
 		}
 	}
 

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -12,20 +12,23 @@ func (c *Config) validate() error {
 		errs.appendFieldError("BUILDKITE_SPLITTER_RETRY_COUNT", "was %d, must be greater than or equal to 0", c.MaxRetries)
 	}
 
-	if got, min := c.Parallelism, 1; got < min {
+	if c.Parallelism == nil {
+		errs.appendFieldError("BUILDKITE_PARALLEL_JOB_COUNT", "not set in environment")
+	} else if got, min := *c.Parallelism, 1; got < min {
 		errs.appendFieldError("BUILDKITE_PARALLEL_JOB_COUNT", "was %d, must be greater than or equal to %d", got, min)
 	}
 
-	if got, max := c.Parallelism, 1000; got > max {
-		errs.appendFieldError("BUILDKITE_PARALLEL_JOB_COUNT", "was %d, must not be greater than %d", got, max)
-	}
-
-	if got, min := c.NodeIndex, 0; got < 0 {
-		errs.appendFieldError("BUILDKITE_PARALLEL_JOB", "was %d, must be greater than or equal to %d", got, min)
-	}
-
-	if got, max := c.NodeIndex, c.Parallelism-1; got > max {
-		errs.appendFieldError("BUILDKITE_PARALLEL_JOB", "was %d, must not be greater than %d", got, max)
+	if c.NodeIndex == nil {
+		errs.appendFieldError("BUILDKITE_PARALLEL_JOB", "not set in environment")
+	} else {
+		if got, min := *c.NodeIndex, 0; got < 0 {
+			errs.appendFieldError("BUILDKITE_PARALLEL_JOB", "was %d, must be greater than or equal to %d", got, min)
+		}
+		if c.Parallelism != nil {
+			if got, max := *c.NodeIndex, *c.Parallelism-1; got > max {
+				errs.appendFieldError("BUILDKITE_PARALLEL_JOB", "was %d, must not be greater than %d", got, max)
+			}
+		}
 	}
 
 	if c.ServerBaseUrl != "" {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -11,16 +11,6 @@ func (c *Config) validate() error {
 		c.errs.appendFieldError("BUILDKITE_SPLITTER_RETRY_COUNT", "was %d, must be greater than or equal to 0", c.MaxRetries)
 	}
 
-	if c.errs["BUILDKITE_PARALLEL_JOB_COUNT"] == nil {
-		if got, min := c.Parallelism, 1; got < min {
-			c.errs.appendFieldError("BUILDKITE_PARALLEL_JOB_COUNT", "was %d, must be greater than or equal to %d", got, min)
-		}
-
-		if got, max := c.Parallelism, 1000; got > max {
-			c.errs.appendFieldError("BUILDKITE_PARALLEL_JOB_COUNT", "was %d, must not be greater than %d", got, max)
-		}
-	}
-
 	if c.errs["BUILDKITE_PARALLEL_JOB"] == nil {
 		if got, min := c.NodeIndex, 0; got < 0 {
 			c.errs.appendFieldError("BUILDKITE_PARALLEL_JOB", "was %d, must be greater than or equal to %d", got, min)
@@ -30,6 +20,16 @@ func (c *Config) validate() error {
 			if got, max := c.NodeIndex, c.Parallelism-1; got > max {
 				c.errs.appendFieldError("BUILDKITE_PARALLEL_JOB", "was %d, must not be greater than %d", got, max)
 			}
+		}
+	}
+
+	if c.errs["BUILDKITE_PARALLEL_JOB_COUNT"] == nil {
+		if got, min := c.Parallelism, 1; got < min {
+			c.errs.appendFieldError("BUILDKITE_PARALLEL_JOB_COUNT", "was %d, must be greater than or equal to %d", got, min)
+		}
+
+		if got, max := c.Parallelism, 1000; got > max {
+			c.errs.appendFieldError("BUILDKITE_PARALLEL_JOB_COUNT", "was %d, must not be greater than %d", got, max)
 		}
 	}
 

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -6,55 +6,55 @@ import (
 
 // validate checks if the Config struct is valid and returns InvalidConfigError if it's invalid.
 func (c *Config) validate() error {
-	var errs InvalidConfigError
 
 	if c.MaxRetries < 0 {
-		errs.appendFieldError("BUILDKITE_SPLITTER_RETRY_COUNT", "was %d, must be greater than or equal to 0", c.MaxRetries)
+		c.errs.appendFieldError("BUILDKITE_SPLITTER_RETRY_COUNT", "was %d, must be greater than or equal to 0", c.MaxRetries)
 	}
 
-	if c.Parallelism == nil {
-		errs.appendFieldError("BUILDKITE_PARALLEL_JOB_COUNT", "not set in environment")
-	} else if got, min := *c.Parallelism, 1; got < min {
-		errs.appendFieldError("BUILDKITE_PARALLEL_JOB_COUNT", "was %d, must be greater than or equal to %d", got, min)
-	}
-
-	if c.NodeIndex == nil {
-		errs.appendFieldError("BUILDKITE_PARALLEL_JOB", "not set in environment")
-	} else {
-		if got, min := *c.NodeIndex, 0; got < 0 {
-			errs.appendFieldError("BUILDKITE_PARALLEL_JOB", "was %d, must be greater than or equal to %d", got, min)
+	if c.errs["BUILDKITE_PARALLEL_JOB_COUNT"] == nil {
+		if got, min := c.Parallelism, 1; got < min {
+			c.errs.appendFieldError("BUILDKITE_PARALLEL_JOB_COUNT", "was %d, must be greater than or equal to %d", got, min)
 		}
-		if c.Parallelism != nil {
-			if got, max := *c.NodeIndex, *c.Parallelism-1; got > max {
-				errs.appendFieldError("BUILDKITE_PARALLEL_JOB", "was %d, must not be greater than %d", got, max)
-			}
+
+		if got, max := c.Parallelism, 1000; got > max {
+			c.errs.appendFieldError("BUILDKITE_PARALLEL_JOB_COUNT", "was %d, must not be greater than %d", got, max)
+		}
+	}
+
+	if c.errs["BUILDKITE_PARALLEL_JOB"] == nil && c.errs["BUILDKITE_PARALLEL_JOB_COUNT"] == nil {
+		if got, min := c.NodeIndex, 0; got < 0 {
+			c.errs.appendFieldError("BUILDKITE_PARALLEL_JOB", "was %d, must be greater than or equal to %d", got, min)
+		}
+
+		if got, max := c.NodeIndex, c.Parallelism-1; got > max {
+			c.errs.appendFieldError("BUILDKITE_PARALLEL_JOB", "was %d, must not be greater than %d", got, max)
 		}
 	}
 
 	if c.ServerBaseUrl != "" {
 		if _, err := url.ParseRequestURI(c.ServerBaseUrl); err != nil {
-			errs.appendFieldError("BUILDKITE_SPLITTER_BASE_URL", "must be a valid URL")
+			c.errs.appendFieldError("BUILDKITE_SPLITTER_BASE_URL", "must be a valid URL")
 		}
 	}
 
 	if c.AccessToken == "" {
-		errs.appendFieldError("BUILDKITE_SPLITTER_API_ACCESS_TOKEN", "must not be blank")
+		c.errs.appendFieldError("BUILDKITE_SPLITTER_API_ACCESS_TOKEN", "must not be blank")
 	}
 
 	if c.OrganizationSlug == "" {
-		errs.appendFieldError("BUILDKITE_ORGANIZATION_SLUG", "must not be blank")
+		c.errs.appendFieldError("BUILDKITE_ORGANIZATION_SLUG", "must not be blank")
 	}
 
 	if c.SuiteSlug == "" {
-		errs.appendFieldError("BUILDKITE_SPLITTER_SUITE_SLUG", "must not be blank")
+		c.errs.appendFieldError("BUILDKITE_SPLITTER_SUITE_SLUG", "must not be blank")
 	}
 
 	if c.ResultPath == "" {
-		errs.appendFieldError("ResultPath", "must not be blank")
+		c.errs.appendFieldError("ResultPath", "must not be blank")
 	}
 
-	if len(errs) > 0 {
-		return errs
+	if len(c.errs) > 0 {
+		return c.errs
 	}
 
 	return nil

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -12,7 +12,7 @@ func (c *Config) validate() error {
 	}
 
 	// We validate BUILDKITE_PARALLEL_JOB and BUILDKITE_PARALLEL_JOB_COUNT in two steps.
-	// 1. Validate the type and presence of BUILDKITE_PARALLEL_JOB and BUILDKITE_PARALLEL_JOB_COUNT when reading them from the environment.
+	// 1. Validate the type and presence of BUILDKITE_PARALLEL_JOB and BUILDKITE_PARALLEL_JOB_COUNT when reading them from the environment. See readFromEnv() in ./read.go.
 	// 2. Validate the range of BUILDKITE_PARALLEL_JOB and BUILDKITE_PARALLEL_JOB_COUNT
 	//
 	// This is the second step. We don't validate the range of BUILDKITE_PARALLEL_JOB and BUILDKITE_PARALLEL_JOB_COUNT if the first validation step fails.

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -11,6 +11,15 @@ func (c *Config) validate() error {
 		c.errs.appendFieldError("BUILDKITE_SPLITTER_RETRY_COUNT", "was %d, must be greater than or equal to 0", c.MaxRetries)
 	}
 
+	// We validate BUILDKITE_PARALLEL_JOB and BUILDKITE_PARALLEL_JOB_COUNT in two steps.
+	// 1. Validate the type and presence of BUILDKITE_PARALLEL_JOB and BUILDKITE_PARALLEL_JOB_COUNT when reading them from the environment.
+	// 2. Validate the range of BUILDKITE_PARALLEL_JOB and BUILDKITE_PARALLEL_JOB_COUNT
+	//
+	// This is the second step. We don't validate the range of BUILDKITE_PARALLEL_JOB and BUILDKITE_PARALLEL_JOB_COUNT if the first validation step fails.
+	//
+	// The order of the range validation matters.
+	// The range validation of BUILDKITE_PARALLEL_JOB depends on the result of BUILDKITE_PARALLEL_JOB_COUNT validation at the first step.
+	// We need to validate the range of BUILDKITE_PARALLEL_JOB first before we add the range validation error to BUILDKITE_PARALLEL_JOB_COUNT.
 	if c.errs["BUILDKITE_PARALLEL_JOB"] == nil {
 		if got, min := c.NodeIndex, 0; got < 0 {
 			c.errs.appendFieldError("BUILDKITE_PARALLEL_JOB", "was %d, must be greater than or equal to %d", got, min)

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -16,6 +16,7 @@ func createConfig() Config {
 		AccessToken:      "my_token",
 		MaxRetries:       3,
 		ResultPath:       "tmp/result-*.json",
+		errs:             InvalidConfigError{},
 	}
 }
 
@@ -27,7 +28,7 @@ func TestConfigValidate(t *testing.T) {
 }
 
 func TestConfigValidate_Empty(t *testing.T) {
-	c := Config{}
+	c := Config{errs: InvalidConfigError{}}
 	err := c.validate()
 
 	if !errors.As(err, new(InvalidConfigError)) {
@@ -107,8 +108,8 @@ func TestConfigValidate_Invalid(t *testing.T) {
 				t.Errorf("config.validate() error length = %d, want 1", len(invConfigError))
 			}
 
-			if invConfigError[0].name != s.name {
-				t.Errorf("config.validate() error name = %s, want %s", invConfigError[0].name, s.name)
+			if len(invConfigError[s.name]) != 1 {
+				t.Errorf("config.validate() error for %s length = %d, want 1", s.name, len(invConfigError[s.name]))
 			}
 		})
 	}

--- a/main.go
+++ b/main.go
@@ -75,7 +75,7 @@ func main() {
 	debug.Printf("My favourite ice cream is %s", testPlan.Experiment)
 
 	// get plan for this node
-	thisNodeTask := testPlan.Tasks[strconv.Itoa(cfg.NodeIndex)]
+	thisNodeTask := testPlan.Tasks[strconv.Itoa(*cfg.NodeIndex)]
 
 	// execute tests
 	runnableTests := []string{}
@@ -209,7 +209,7 @@ func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg confi
 	handleError := func(err error) (plan.TestPlan, error) {
 		if errors.Is(err, api.ErrRetryTimeout) {
 			fmt.Println("Could not fetch or create plan from server, using fallback mode. Your build may take longer than usual.")
-			p := plan.CreateFallbackPlan(files, cfg.Parallelism)
+			p := plan.CreateFallbackPlan(files, *cfg.Parallelism)
 			return p, nil
 		}
 		return plan.TestPlan{}, err
@@ -224,7 +224,7 @@ func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg confi
 		// In this case, we should create a fallback plan.
 		if len(cachedPlan.Tasks) == 0 {
 			fmt.Println("Error plan received, using fallback mode. Your build may take longer than usual.")
-			testPlan := plan.CreateFallbackPlan(files, cfg.Parallelism)
+			testPlan := plan.CreateFallbackPlan(files, *cfg.Parallelism)
 			return testPlan, nil
 		}
 
@@ -250,7 +250,7 @@ func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg confi
 	// In this case, we should create a fallback plan.
 	if len(testPlan.Tasks) == 0 {
 		fmt.Println("Error plan received, using fallback mode. Your build may take longer than usual.")
-		testPlan = plan.CreateFallbackPlan(files, cfg.Parallelism)
+		testPlan = plan.CreateFallbackPlan(files, *cfg.Parallelism)
 	}
 
 	debug.Printf("Test plan created. Identifier: %q", cfg.Identifier)
@@ -275,7 +275,7 @@ func createRequestParam(ctx context.Context, cfg config.Config, files []string, 
 		debug.Println("Splitting by file")
 		return api.TestPlanParams{
 			Identifier:  cfg.Identifier,
-			Parallelism: cfg.Parallelism,
+			Parallelism: *cfg.Parallelism,
 			Branch:      cfg.Branch,
 			Tests: api.TestPlanParamsTest{
 				Files: testFiles,
@@ -299,7 +299,7 @@ func createRequestParam(ctx context.Context, cfg config.Config, files []string, 
 		debug.Println("No filtered files found")
 		return api.TestPlanParams{
 			Identifier:  cfg.Identifier,
-			Parallelism: cfg.Parallelism,
+			Parallelism: *cfg.Parallelism,
 			Branch:      cfg.Branch,
 			Tests: api.TestPlanParamsTest{
 				Files: testFiles,
@@ -336,7 +336,7 @@ func createRequestParam(ctx context.Context, cfg config.Config, files []string, 
 
 	return api.TestPlanParams{
 		Identifier:  cfg.Identifier,
-		Parallelism: cfg.Parallelism,
+		Parallelism: *cfg.Parallelism,
 		Branch:      cfg.Branch,
 		Tests: api.TestPlanParamsTest{
 			Examples: examples,

--- a/main.go
+++ b/main.go
@@ -75,7 +75,7 @@ func main() {
 	debug.Printf("My favourite ice cream is %s", testPlan.Experiment)
 
 	// get plan for this node
-	thisNodeTask := testPlan.Tasks[strconv.Itoa(*cfg.NodeIndex)]
+	thisNodeTask := testPlan.Tasks[strconv.Itoa(cfg.NodeIndex)]
 
 	// execute tests
 	runnableTests := []string{}
@@ -209,7 +209,7 @@ func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg confi
 	handleError := func(err error) (plan.TestPlan, error) {
 		if errors.Is(err, api.ErrRetryTimeout) {
 			fmt.Println("Could not fetch or create plan from server, using fallback mode. Your build may take longer than usual.")
-			p := plan.CreateFallbackPlan(files, *cfg.Parallelism)
+			p := plan.CreateFallbackPlan(files, cfg.Parallelism)
 			return p, nil
 		}
 		return plan.TestPlan{}, err
@@ -224,7 +224,7 @@ func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg confi
 		// In this case, we should create a fallback plan.
 		if len(cachedPlan.Tasks) == 0 {
 			fmt.Println("Error plan received, using fallback mode. Your build may take longer than usual.")
-			testPlan := plan.CreateFallbackPlan(files, *cfg.Parallelism)
+			testPlan := plan.CreateFallbackPlan(files, cfg.Parallelism)
 			return testPlan, nil
 		}
 
@@ -250,7 +250,7 @@ func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg confi
 	// In this case, we should create a fallback plan.
 	if len(testPlan.Tasks) == 0 {
 		fmt.Println("Error plan received, using fallback mode. Your build may take longer than usual.")
-		testPlan = plan.CreateFallbackPlan(files, *cfg.Parallelism)
+		testPlan = plan.CreateFallbackPlan(files, cfg.Parallelism)
 	}
 
 	debug.Printf("Test plan created. Identifier: %q", cfg.Identifier)
@@ -275,7 +275,7 @@ func createRequestParam(ctx context.Context, cfg config.Config, files []string, 
 		debug.Println("Splitting by file")
 		return api.TestPlanParams{
 			Identifier:  cfg.Identifier,
-			Parallelism: *cfg.Parallelism,
+			Parallelism: cfg.Parallelism,
 			Branch:      cfg.Branch,
 			Tests: api.TestPlanParamsTest{
 				Files: testFiles,
@@ -299,7 +299,7 @@ func createRequestParam(ctx context.Context, cfg config.Config, files []string, 
 		debug.Println("No filtered files found")
 		return api.TestPlanParams{
 			Identifier:  cfg.Identifier,
-			Parallelism: *cfg.Parallelism,
+			Parallelism: cfg.Parallelism,
 			Branch:      cfg.Branch,
 			Tests: api.TestPlanParamsTest{
 				Files: testFiles,
@@ -336,7 +336,7 @@ func createRequestParam(ctx context.Context, cfg config.Config, files []string, 
 
 	return api.TestPlanParams{
 		Identifier:  cfg.Identifier,
-		Parallelism: *cfg.Parallelism,
+		Parallelism: cfg.Parallelism,
 		Branch:      cfg.Branch,
 		Tests: api.TestPlanParamsTest{
 			Examples: examples,


### PR DESCRIPTION
### Description
Currently when BUILDKITE_PARALLEL_JOB and BUILDKITE_PARALLEL_JOB_COUNT are not set. The error message looks like this. 
```
 ./run-splitter
Buildkite Test Splitter: Invalid configuration
BUILDKITE_PARALLEL_JOB was "", must be a number
BUILDKITE_PARALLEL_JOB was 0, must not be greater than -1
BUILDKITE_PARALLEL_JOB_COUNT was "", must be a number
BUILDKITE_PARALLEL_JOB_COUNT was 0, must be greater than or equal to 1
```

We found the error message `BUILDKITE_PARALLEL_JOB was 0, must not be greater than -1` and `BUILDKITE_PARALLEL_JOB_COUNT was 0, must be greater than or equal to 1` confusing when the value of the env variables are not set


This PR updates the validation logic and prints more readable error message. 
The current code structure validates BUILDKITE_PARALLEL_JOB and BUILDKITE_PARALLEL_JOB_COUNT in two steps. 1. validate the type and presence of the env  2. validate the content of the env. 

This PR will skip the content/range validation if the first step failed for `BUILDKITE_PARALLEL_JOB_COUNT` or `BUILDKITE_PARALLEL_JOB`. The result looks like:

```
./test-splitter
Buildkite Test Splitter: Invalid configuration...
BUILDKITE_BUILD_ID must not be blank
BUILDKITE_ORGANIZATION_SLUG must not be blank
BUILDKITE_PARALLEL_JOB was "", must be a number
BUILDKITE_PARALLEL_JOB_COUNT was "", must be a number
BUILDKITE_SPLITTER_API_ACCESS_TOKEN must not be blank
BUILDKITE_SPLITTER_SUITE_SLUG must not be blank
BUILDKITE_STEP_ID must not be blank
ResultPath must not be blank
```

### Changes

- Add a map `errs` field to Config struct to keep truck of all errors for each environment variable
- Conditionally skip value check if  `BUILDKITE_PARALLEL_JOB` or `BUILDKITE_PARALLEL_JOB_COUNT` has invalid type. 


