### PR TITLE
Ignore `-rc` tags when releasing stable version

### DIFF
--- a/.buildkite/steps/release.sh
+++ b/.buildkite/steps/release.sh
@@ -4,6 +4,22 @@ tag=$(buildkite-agent meta-data get "release-version")
 
 git tag "${tag}"
 
+# When releasing a stable version, we want the changelog
+# in GitHub to be based on the previous stable version.
+#
+# For illustrations, consider the following tags:
+# - v1.0.0
+# - v1.0.1-rc.1
+# - v1.0.1-rc.2
+#
+# When releasing v1.0.1, we want the changelog to be based on v1.0.0, not v1.0.1-rc.2.
+# Hoever, when releasing v1.0.1-rc.3, we want the changelog to be based on v1.0.1-rc.2.
+#
+# To do this, we need to ignore all '-rc' tags when releasing a stable version.
+if [[ ! "${tag}" =~ "-rc" ]]; then
+  export GORELEASER_IGNORE_TAG="*-rc.*"
+fi
+
 echo "--- :key: :buildkite: Login to Buildkite Packages"
  buildkite-agent oidc request-token \
    --audience "https://packages.buildkite.com/buildkite/test-splitter-docker" \

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,6 +34,10 @@ brews:
       name: homebrew-buildkite
       branch: master
 
+git:
+  ignore_tags:
+    - '{{ envOrDefault "GORELEASER_IGNORE_TAG" ""}}'
+
 dockers:
   - image_templates:
       - "packages.buildkite.com/buildkite/test-splitter-docker/test-splitter:v{{ .Version }}-amd64"


### PR DESCRIPTION
### Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->
We create GitHub release using `goreleaser`. By default, `goreleaser` will generate the changelog by comparing the current version with the previous version. The changelog for `v0.9.0` is generated by comparing with `v0.9.0-rc.4` as you can see below:
![Screenshot 2024-09-12 at 9 36 39 AM](https://github.com/user-attachments/assets/f4a12b9f-0167-4c9f-beaf-6edb4ee5d5fd)


However, this is not always the case. When we release a stable version from a release candidate `-rc.*` version, we want the changelog in GitHub release to be compared with the latest stable version.
For illustration, consider following versions that has been released.
- `v0.8.1`
- `v0.9.0-rc.1`
- `v0.9.0-rc.2` 
- `v0.9.0-rc.3` 
- `v0.9.0-rc.4`
 
When we are releasing `v0.9.0`, we want it to be compared with `v0.8.1` instead of `v0.9.0-rc.4`. This is also the default behaviour in GitHub Release (without `goreleaser`).

https://github.com/user-attachments/assets/72c6d261-4031-4b15-b8fc-7938b3bda382


`goreleaser` doesn't have a straight forward option to achieve this, but we can use `ignore_tags` to tell `goreleaser` to ignore `-rc` versions when we release a stable version.

